### PR TITLE
Use oraclejdk8 for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: oraclejdk8
 branches: 
 only:
 - master


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Travis does not support Open JDK 8 [1]. This updates to use Oracle JDK 8 for the build.

[1] https://docs.travis-ci.com/user/languages/java/#Overview

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [x] [Brian van de Boogaard](https://github.com/b-boogaard)
