### PR TITLE
Update documentation site url in README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk8
+jdk: oraclejdk8
 branches: 
 only:
 - master

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Beadledom is a bundle of common components required for building JAX-RS web services. It is the starting point
 for new services, and the core of Beadledom provides health checks, monitoring via Stagemonitor,
 API docs via Swagger, JSON serialization via Jackson, and integration of these components with
-Guice. For more information on creating a service check out our [getting started guide](http://cerner.github.io/beadledom/manual/getting_started.html).
+Guice. For more information on creating a service check out our [documentation site](http://cerner.github.io/beadledom/).
 
 Beadledom is made up of the following components:
 


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------
Correct site URL in `README.md`.

Reviewers
----

- [x] [John Leacox](https://github.com/johnlcox)
- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
