### PR TITLE
Remove unnecessary release plugin configuration  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ deploy:
 branches:
   only:
     - master
+    - /([0-9]*\.[0-9]*\.*[0-9]*-*)\w+$/
 env:
   global:
   - GPG_DIR=${TRAVIS_BUILD_DIR}/.travis

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -13,6 +13,9 @@
     <profiles>
         <profile>
             <id>ossrh</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <properties>
                 <gpg.executable>gpg2</gpg.executable>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,7 @@
 # Releasing Beadledom
 
+The [Preparing for the Release](preparing-for-the-release) section is needed only for the initial setup. If the setup is already made once, skip to [Release process](release-process)
+
 ## Preparing for the Release
 
 * A valid Sonatype user account is required to release this project. To create an account sign up with [Sonatype](https://issues.sonatype.org/secure/Signup!default.jspa).
@@ -47,19 +49,16 @@
  
 ## Release process
 
-After preparing the machine follow the below steps
+After preparing the project for the release follow the below steps
 
-* Prepare the project for releasing
+* Update the changelog with the release data for the releasing version.
+* Commit the change.
+* Prepare the project for releasing.
 
     ```
     mvn clean release:prepare
     ```
-
-* Release the project
-
-    ```
-    mvn clean release:perform
-    ```
+    The below command will prompt for the release version. Give the same version as in the changelog. After that it also prompts for the next development version. Give the appropriate version number for the next release.
 
 * Push the local commits and tags
 

--- a/pom.xml
+++ b/pom.xml
@@ -626,8 +626,6 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <tagNameFormat>@{project.version}</tagNameFormat>
                     <useReleaseProfile>false</useReleaseProfile>
-                    <releaseProfiles>release</releaseProfiles>
-                    <goals>deploy</goals>
                 </configuration>
                 <dependencies>
                     <dependency>
@@ -708,7 +706,7 @@
                     <configuration>
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -927,9 +925,6 @@
     <profiles>
         <profile>
             <id>ossrh</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>
@@ -940,7 +935,7 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------
* Removed the unnecessary configuration for maven-release-plugin
* Update the release guide
* updated the travis configuration to also build tags.

How was it tested?
----
n/a

Reviewers
----

- [x] [John Leacox](https://github.com/johnlcox)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
