### PR TITLE
Downgrade client dependency on Resteasy to 3.0.12.Final

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -28,6 +28,8 @@
 
     <properties>
         <java.version>1.6</java.version>
+        <!-- Cannot go past 3.0.12.Final since 3.0.13.Final+ require Java 7 -->
+        <resteasy.client.version>3.0.12.Final</resteasy.client.version>
     </properties>
     
     <dependencyManagement>
@@ -46,6 +48,26 @@
                 <groupId>com.cerner.beadledom</groupId>
                 <artifactId>beadledom-client-example-service</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>jaxrs-api</artifactId>
+                <version>${resteasy.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-client</artifactId>
+                <version>${resteasy.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-guice</artifactId>
+                <version>${resteasy.client.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxrs</artifactId>
+                <version>${resteasy.client.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Downgraded the client modules to use Resteasy 3.0.12.Final so that it is compatible with Java 6. 3.0.13.Final+ require Java 7. Fixes #9.


How was it tested?
----

Manually built (`mvn clean install`) the client modules using java 6.

How to test
----

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [x] [Supriya Lal](https://github.com/lal-s)
- [x] [Brian van de Boogaard](https://github.com/b-boogaard)
