### PR TITLE
Fix infinite loop in ResteasyContextListener when injector has parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Beadledom Changelog
 
-## 2.4 - Unreleased
+## 2.4 - In Development
 
 ### Defects Corrected
-* Fixed infinite loop in `ResteasyContextListener` when injector has a parent.
+* Removed unnecessary loop in `ResteasyContextListener` which would cause infinite loop if run.
 
 ## 2.3 - 24 01 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 2.4 - Unreleased
+
+### Defects Corrected
+* Fixed infinite loop in `ResteasyContextListener` when injector has a parent.
+
 ## 2.3 - 24 01 2017
 
 ### Enhancements

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@
 * Sundeep Paruvu [@sparuvu][sundeep-paruvu]
 * Brian van de Boogaard [@b-boogaard][brian-boogaard]
 * Supriya Lal [@lal-s][supriya-lal]
+* Jason Gassel [@jpeg][jason-gassel]
 
 [john-leacox]: https://github.com/johnlcox
 [jacob-williams]: https://github.com/brokensandals
@@ -19,3 +20,4 @@
 [sundeep-paruvu]: https://github.com/sparuvu
 [brian-boogaard]: https://github.com/b-boogaard
 [supriya-lal]: https://github.com/lal-s
+[jason-gassel]: https://github.com/jpeg

--- a/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyContextListener.java
+++ b/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyContextListener.java
@@ -5,6 +5,8 @@ import com.cerner.beadledom.configuration.ConfigurationSource;
 import com.cerner.beadledom.lifecycle.GuiceLifecycleContainers;
 import com.cerner.beadledom.lifecycle.LifecycleContainer;
 import com.cerner.beadledom.lifecycle.LifecycleInjector;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -34,10 +36,6 @@ public abstract class ResteasyContextListener extends ResteasyBootstrap implemen
     super.contextInitialized(event);
 
     final ServletContext context = event.getServletContext();
-    final Registry registry = (Registry) context.getAttribute(Registry.class.getName());
-    final ResteasyProviderFactory providerFactory =
-        (ResteasyProviderFactory) context.getAttribute(ResteasyProviderFactory.class.getName());
-    final ModuleProcessor processor = new ModuleProcessor(registry, providerFactory);
 
     final List<? extends Module> appModules = getModules(context);
 
@@ -48,11 +46,7 @@ public abstract class ResteasyContextListener extends ResteasyBootstrap implemen
 
     withInjector(injector);
 
-    processor.processInjector(injector);
-    while (injector.getParent() != null) {
-      Injector parent = injector.getParent();
-      processor.processInjector(parent);
-    }
+    processInjector(context, injector);
   }
 
   @Override
@@ -76,4 +70,21 @@ public abstract class ResteasyContextListener extends ResteasyBootstrap implemen
    * Returns the list of Guice modules to be used with Resteasy.
    */
   protected abstract List<? extends Module> getModules(ServletContext context);
+
+  /**
+   * Processes module bindings in the Guice injector.
+   */
+  @VisibleForTesting
+  public void processInjector(ServletContext context, Injector injector) {
+    final Registry registry = (Registry) context.getAttribute(Registry.class.getName());
+    final ResteasyProviderFactory providerFactory =
+        (ResteasyProviderFactory) context.getAttribute(ResteasyProviderFactory.class.getName());
+    final ModuleProcessor processor = new ModuleProcessor(registry, providerFactory);
+
+    processor.processInjector(injector);
+    while (injector.getParent() != null) {
+      injector = injector.getParent();
+      processor.processInjector(injector);
+    }
+  }
 }

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
@@ -2,7 +2,7 @@ package com.cerner.beadledom.resteasy
 
 import com.cerner.beadledom.configuration._
 import com.cerner.beadledom.resteasy.fauxservice.FauxContextListener
-import com.google.inject.{AbstractModule, Binding, Injector, Key, Module, Singleton}
+import com.google.inject.{AbstractModule, Injector, Module, Singleton}
 import java.io.FileReader
 import java.util
 import javax.annotation.{PostConstruct, PreDestroy}
@@ -138,28 +138,6 @@ class BaseContextListenerSpec
 
         lifecycleHolder.hasExecutedStartup must be(true)
         lifecycleHolder.hasExecutedShutdown must be(true)
-      }
-
-      it("processes parent injectors") {
-        val contextListenerUtil = new ContextListeners(List())
-
-        val contextListener = contextListenerUtil.getContextListener
-
-        val injectors = List.fill(3)(mock[Injector])
-        when(injectors(0).getParent).thenReturn(injectors(1))
-        when(injectors(1).getParent).thenReturn(injectors(2))
-        when(injectors(2).getParent).thenReturn(null)
-        injectors.foreach(x => when(x.getBindings).thenReturn(Map[Key[_],Binding[_]]().asJava))
-
-        contextListener.processInjector(context, injectors(0))
-
-        verify(injectors(0), times(2)).getParent
-        verify(injectors(1), times(2)).getParent
-        verify(injectors(2), times(1)).getParent
-
-        // Verify bindings were processed for all injectors
-        injectors.foreach(x => verify(x, times(1)).getBindings)
-
       }
     }
 

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
@@ -2,7 +2,7 @@ package com.cerner.beadledom.resteasy
 
 import com.cerner.beadledom.configuration._
 import com.cerner.beadledom.resteasy.fauxservice.FauxContextListener
-import com.google.inject.{AbstractModule, Injector, Module, Singleton}
+import com.google.inject.{AbstractModule, Binding, Injector, Key, Module, Singleton}
 import java.io.FileReader
 import java.util
 import javax.annotation.{PostConstruct, PreDestroy}
@@ -138,6 +138,28 @@ class BaseContextListenerSpec
 
         lifecycleHolder.hasExecutedStartup must be(true)
         lifecycleHolder.hasExecutedShutdown must be(true)
+      }
+
+      it("processes parent injectors") {
+        val contextListenerUtil = new ContextListeners(List())
+
+        val contextListener = contextListenerUtil.getContextListener
+
+        val injectors = List.fill(3)(mock[Injector])
+        when(injectors(0).getParent).thenReturn(injectors(1))
+        when(injectors(1).getParent).thenReturn(injectors(2))
+        when(injectors(2).getParent).thenReturn(null)
+        injectors.foreach(x => when(x.getBindings).thenReturn(Map[Key[_],Binding[_]]().asJava))
+
+        contextListener.processInjector(context, injectors(0))
+
+        verify(injectors(0), times(2)).getParent
+        verify(injectors(1), times(2)).getParent
+        verify(injectors(2), times(1)).getParent
+
+        // Verify bindings were processed for all injectors
+        injectors.foreach(x => verify(x, times(1)).getBindings)
+
       }
     }
 


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

An infinite loop would occur in `ResteasyContextListener` if the Guice injector had a parent injector.


How was it tested?
----

Added new unit test and verified that it resulted in an infinite loop before the fix was implemented.


How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
