### PR TITLE
WebApplicationExceptionMapper is called when exceptions are thrown by the checkParam method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Beadledom Changelog
 
-## 2.4
+## 2.4 - In Development
 
 ### Defects Corrected
 * WebApplicationException mapper is called when exceptions are thrown by the checkParam method in JaxRsParamConditions class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 2.4
+
+### Defects Corrected
+* WebApplicationException mapper is called when exceptions are thrown by the checkParam method in JaxRsParamConditions class.
+
 ## 2.3 - 24 01 2017
 
 ### Enhancements

--- a/jaxrs/src/main/java/com/cerner/beadledom/jaxrs/JaxRsParamConditions.java
+++ b/jaxrs/src/main/java/com/cerner/beadledom/jaxrs/JaxRsParamConditions.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
  * </pre>
  *
  * @author John Leacox
+ * @author Nimesh Subramanian
  */
 public class JaxRsParamConditions {
   private JaxRsParamConditions() {

--- a/jaxrs/src/main/java/com/cerner/beadledom/jaxrs/JaxRsParamConditions.java
+++ b/jaxrs/src/main/java/com/cerner/beadledom/jaxrs/JaxRsParamConditions.java
@@ -43,10 +43,9 @@ public class JaxRsParamConditions {
   public static void checkParam(boolean expression, Object errorMessage) {
     if (!expression) {
       Response response = Response.status(Response.Status.BAD_REQUEST)
-          .entity(String.valueOf(errorMessage))
           .type(MediaType.TEXT_PLAIN)
           .build();
-      throw new WebApplicationException(response);
+      throw new WebApplicationException(String.valueOf(errorMessage), response);
     }
   }
 }

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
@@ -2,23 +2,25 @@ package com.cerner.beadledom.jaxrs
 
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.MediaType
-import org.scalatest.{FunSpec, ShouldMatchers}
+import org.scalatest.{FunSpec, MustMatchers}
 
 /**
  * Spec tests for {@link JaxRsParamConditions}.
  *
  * @author John Leacox
+ * @author Nimesh Subramanian
  */
-class JaxRsParamConditionsSpec extends FunSpec with ShouldMatchers {
+class JaxRsParamConditionsSpec extends FunSpec with MustMatchers {
   describe("JaxRsParamConditions") {
     describe("checkParam") {
       it("should throw WebApplicationException with 400 status when expression is false") {
         val exception = intercept[WebApplicationException] {
           JaxRsParamConditions.checkParam(false, "some message")
         }
-        exception.getResponse.getStatus should be(400)
-        exception.getResponse.getMediaType should be(MediaType.TEXT_PLAIN_TYPE)
-        exception.getMessage should be("some message")
+
+        exception.getResponse.getStatus must be(400)
+        exception.getResponse.getMediaType must be(MediaType.TEXT_PLAIN_TYPE)
+        exception.getMessage must be("some message")
       }
 
       it("should not throw an exception when expression is true") {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
@@ -18,6 +18,7 @@ class JaxRsParamConditionsSpec extends FunSpec with ShouldMatchers {
         }
         exception.getResponse.getStatus should be(400)
         exception.getResponse.getMediaType should be(MediaType.TEXT_PLAIN_TYPE)
+        exception.getMessage should be("some message")
       }
 
       it("should not throw an exception when expression is true") {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
@@ -17,7 +17,6 @@ class JaxRsParamConditionsSpec extends FunSpec with ShouldMatchers {
           JaxRsParamConditions.checkParam(false, "some message")
         }
         exception.getResponse.getStatus should be(400)
-        exception.getResponse.getEntity should be("some message")
         exception.getResponse.getMediaType should be(MediaType.TEXT_PLAIN_TYPE)
       }
 

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.{FunSpec, MustMatchers}
 class JaxRsParamConditionsSpec extends FunSpec with MustMatchers {
   describe("JaxRsParamConditions") {
     describe("checkParam") {
-      it("should throw WebApplicationException with 400 status when expression is false") {
+      it("must throw WebApplicationException with 400 status when expression is false") {
         val exception = intercept[WebApplicationException] {
           JaxRsParamConditions.checkParam(false, "some message")
         }
@@ -23,7 +23,7 @@ class JaxRsParamConditionsSpec extends FunSpec with MustMatchers {
         exception.getMessage must be("some message")
       }
 
-      it("should not throw an exception when expression is true") {
+      it("must not throw an exception when expression is true") {
         JaxRsParamConditions.checkParam(true, "some message")
       }
     }


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

The WebApplicationExceptionMapper is only called when there isnt a message set in the response.

relevant code from ExceptionHandler.java
```
      if (unwrappedException instanceof WebApplicationException) {
         WebApplicationException wae = (WebApplicationException) unwrappedException;
         if (wae.getResponse() != null && wae.getResponse().getEntity() != null) return wae.getResponse();
      }

      if ((jaxrsResponse = executeExceptionMapper(unwrappedException)) != null) {
         return jaxrsResponse;
      }
```

So with `checkParam` setting the messages, our exception mapper's are not being called. So am removing the message from the response and using a constructor of WebApplicationException that let's me pass both the message and a response.

How was it tested?
----

tested on a local service.

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [x] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
