### PR TITLE
fixes redirects in bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Beadledom Changelog
 
+## 2.4 - In Development
+* Fixed issue with redirects in the bootstrap script.([issue-15](https://github.com/cerner/beadledom/issues/15))
+
 ## 2.3 - 24 01 2017
 
 ### Enhancements

--- a/archetype/bootstrap/bin/install.sh
+++ b/archetype/bootstrap/bin/install.sh
@@ -54,7 +54,7 @@ then
     exec 3>&1
     GET=`which curl`
     printf "$CYAN Found $GREEN curl $CYAN will use $GET for download.$RESET\n\n"
-    HTTP_STATUS=$($GET "-w" "%{http_code}" "-o" "$DEFAULT_INSTALL_DIR/beadledom" "$DEFAULT_REPO/beadledom")
+    HTTP_STATUS=$($GET "-L" "-w" "%{http_code}" "-o" "$DEFAULT_INSTALL_DIR/beadledom" "$DEFAULT_REPO/beadledom")
     exec 1>&3 3>&-
 else
     printf "$RED Cannot find curl which is required for installation. Aborting install.$RESET\n"


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

* Added option `-L` to handle redirects in bootstrap script. With `-L` the `HTTP_STATUS` variable in line 57 is set to `200` and not `301`. 

fixes: issue #15 

How was it tested?
----

* Tested locally

Reviewers
----

- [x] [John Leacox](https://github.com/johnlcox)
- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
