### PR TITLE
Changing archetype based on best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pom.xml.releaseBackup
 deploy_site_key
 pubring.gpg
 secring.gpg
+.tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.4 - In Development
 
 ### Additions
-* Documentation and archetype changes for best practices around service modules.
+* Documentation and archetype changes for best practices for structuring service guice modules.
 
 ### Defects Corrected
 * Removed unnecessary loop in `ResteasyContextListener` which would cause infinite loop if run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.4 - In Development
 
+### Additions
+* Documentation and archetype changes for best practices around service modules.
+
 ### Defects Corrected
 * Removed unnecessary loop in `ResteasyContextListener` which would cause infinite loop if run.
 * Fixed issue with redirects in the bootstrap script ([issue-15](https://github.com/cerner/beadledom/issues/15)).

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
@@ -1,0 +1,31 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+package ${package}.service;
+
+import com.cerner.beadledom.metadata.BuildInfo;
+import com.cerner.beadledom.metadata.ServiceMetadata;
+import com.cerner.beadledom.resteasy.ResteasyModule;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.wordnik.swagger.config.SwaggerConfig;
+import com.wordnik.swagger.core.SwaggerSpec;
+
+public class ResteasyBootstrapModule extends AbstractModule {
+
+  protected void configure() {
+    install(new ResteasyModule());
+
+    BuildInfo buildInfo = BuildInfo.load(getClass().getResourceAsStream("build-info.properties"));
+    bind(BuildInfo.class).toInstance(buildInfo);
+    bind(ServiceMetadata.class).toInstance(ServiceMetadata.create(buildInfo));
+  }
+
+  @Provides
+  SwaggerConfig provideSwaggerConfig(ServiceMetadata serviceMetadata) {
+    SwaggerConfig config = new SwaggerConfig();
+    config.setApiVersion(serviceMetadata.getBuildInfo().getVersion());
+    config.setSwaggerVersion(SwaggerSpec.version());
+    return config;
+  }
+}

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/__name__ContextListener.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/__name__ContextListener.java
@@ -13,6 +13,6 @@ import javax.servlet.ServletContext;
 public class ${name}ContextListener extends ResteasyContextListener {
   @Override
   protected List<? extends Module> getModules(ServletContext context) {
-    return Lists.newArrayList(new ${name}Module());
+    return Lists.newArrayList(new ${name}Module(), new ResteasyBootstrapModule());
   }
 }

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/__name__Module.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/__name__Module.java
@@ -5,31 +5,13 @@ package ${package}.service;
 
 import ${package}.service.resource.HelloWorldResourceImpl;
 import ${package}.api.HelloWorldResource;
-import com.cerner.beadledom.metadata.BuildInfo;
-import com.cerner.beadledom.metadata.ServiceMetadata;
-import com.cerner.beadledom.resteasy.ResteasyModule;
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.wordnik.swagger.config.SwaggerConfig;
-import com.wordnik.swagger.core.SwaggerSpec;
+import com.google.inject.PrivateModule;
 
-public class ${name}Module extends AbstractModule {
+public class ${name}Module extends PrivateModule {
 
   protected void configure() {
-    install(new ResteasyModule());
-
-    BuildInfo buildInfo = BuildInfo.load(getClass().getResourceAsStream("build-info.properties"));
-    bind(BuildInfo.class).toInstance(buildInfo);
-    bind(ServiceMetadata.class).toInstance(ServiceMetadata.create(buildInfo));
-
     bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);
-  }
 
-  @Provides
-  SwaggerConfig provideSwaggerConfig(ServiceMetadata serviceMetadata) {
-    SwaggerConfig config = new SwaggerConfig();
-    config.setApiVersion(serviceMetadata.getBuildInfo().getVersion());
-    config.setSwaggerVersion(SwaggerSpec.version());
-    return config;
+    expose(HelloWorldResource.class);
   }
 }

--- a/docs/source/guides/getting_started.rst
+++ b/docs/source/guides/getting_started.rst
@@ -342,7 +342,7 @@ AwesomeThingModule
     }
   }
 
-``AwesomeThingModule`` is a private module, which contains configuration information for our service. PrivateModule encapsulates the service's environment and only exposes objects needed by for JAX-RS/Resteasy(ex: resource classes, providers and features). It also prevents dependency issues with with a configuration bound to Guice gobally.
+``AwesomeThingModule`` is a private module, which contains configuration information for our service. PrivateModule encapsulates the service's environment and only exposes objects needed for JAX-RS/Resteasy(ex: resource classes, providers and features). It also prevents dependency issues with a configuration bound to Guice gobally.
 
 With this binding :java:`bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);` we are
 telling Guice that whenever we ask for an instance of `HelloWorldResource`_ we want it to inject

--- a/docs/source/guides/getting_started.rst
+++ b/docs/source/guides/getting_started.rst
@@ -342,7 +342,7 @@ AwesomeThingModule
     }
   }
 
-``AwesomeThingModule`` is a private module, which contains configuration information for our service. Only the configuration that is explicitly exposed will be available to other modules.
+``AwesomeThingModule`` is a private module, which contains configuration information for our service. PrivateModule encapsulates the service's environment and only exposes objects needed by for JAX-RS/Resteasy(ex: resource classes, providers and features). It also prevents dependency issues with with a configuration bound to Guice gobally.
 
 With this binding :java:`bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);` we are
 telling Guice that whenever we ask for an instance of `HelloWorldResource`_ we want it to inject

--- a/docs/source/guides/getting_started.rst
+++ b/docs/source/guides/getting_started.rst
@@ -271,7 +271,7 @@ AwesomeThingContextListener
   public class AwesomeThingContextListener extends ResteasyContextListener {
     @Override
     protected List<? extends Module> getModules(ServletContext context) {
-      return Lists.newArrayList(new AwesomeThingModule());
+      return Lists.newArrayList(new AwesomeThingModule(), new ResteasyBootstrapModule());
     }
   }
 
@@ -280,22 +280,24 @@ our service and where we define our base Guice modules and configuration. We won
 into the configuration component if you want to learn more about it (and we recommend you do)
 you can find more documentation `here <https://github.com/cerner/beadledom/tree/master/configuration>`_.
 
-The other method we are overriding here is providing our ``AwesomeThingModule`` so why don't we
-take a look at that next.
+The method we are overriding here is providing our ``AwesomeThingModule``, which is our service module and ``ResteasyBootstrapModule``, which bootstraps ``ResteasyModule`` for our service.
 
-AwesomeThingModule
+
+so Let's take a look at the ``ResteasyBootstrapModule`` next.
+
+ResteasyBootstrapModule
 ++++++++++++++++++
 
 .. code-block:: java
 
-  public class AwesomeThingModule extends AbstractModule {
+  public class ResteasyBootstrapModule extends AbstractModule {
+
     protected void configure() {
       install(new ResteasyModule());
 
       BuildInfo buildInfo = BuildInfo.load(getClass().getResourceAsStream("build-info.properties"));
       bind(BuildInfo.class).toInstance(buildInfo);
       bind(ServiceMetadata.class).toInstance(ServiceMetadata.create(buildInfo));
-      bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);
     }
 
     @Provides
@@ -309,7 +311,7 @@ AwesomeThingModule
 
 This is where we install the main Beadledom module :java:`install(new ResteasyModule());`. Inside
 this module is where Beadledom is going to install and bootstrap the various features it needs
-in order to make our service tick. Below are some of the many awesome features that we get just in installing `ResteasyModule` without any extra efforts
+in order to make our service tick. Below are some of the many awesome features that we get just by installing `ResteasyModule` without any extra efforts
 
 - `Configuration <https://github.com/cerner/beadledom/tree/master/configuration#beadledom-configuration>`_ - lets us access all the configuration through a consistent API.
 - `Health <https://github.com/cerner/beadledom/tree/master/health#beadledom-health>`_ - Health checks for the services
@@ -327,9 +329,25 @@ The next chunk of code
 We pull in the properties from the ``build-info.properties`` and make them available to the service
 and more importantly the healthcheck.
 
-In the next binding :java:`bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);` we are
+AwesomeThingModule
+++++++++++++++++++
+
+.. code-block:: java
+
+  public class AwesomeThingModule extends PrivateModule {
+    protected void configure() {
+      bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);
+
+      expose(HelloWorldResource.class);
+    }
+  }
+
+``AwesomeThingModule`` is a private module, which contains configuration information for our service. Only the configuration that is explicitly exposed will be available to other modules.
+
+With this binding :java:`bind(HelloWorldResource.class).to(HelloWorldResourceImpl.class);` we are
 telling Guice that whenever we ask for an instance of `HelloWorldResource`_ we want it to inject
-the implementation `HelloWorldResourceImpl`_.
+the implementation `HelloWorldResourceImpl`_. And the next line :java:`expose(HelloWorldResource.class);`, exposes `HelloWorldResource`_ to modules that install `AwesomeThingModule`_.
+
 
 That's it! There are additional Beadledom modules that we can install for other functionality, and
 we could even create our own modules or bindings to provide additional classes our service will need

--- a/docs/source/guides/troubleshooting.rst
+++ b/docs/source/guides/troubleshooting.rst
@@ -45,10 +45,10 @@ I am seeing resources from clients being treated as service resource by swagger
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Problem
-  Beadledom clients are automatically generated from an API resources annotated with swagger and JAX-RS annotations.
+  Beadledom clients are automatically generated from API resources annotated with JAX-RS and Swagger annotations.
   API definitions from clients used in a service is getting merged with the service definition.
 
 Suggested solution
-  Make your service module a private module, and expose only your resources. In another module install ``ResteasyModule`` and bootstrap all the configurations needed for resteasy.
+  Make your service module a private module, and expose only your server resources. In another module install ``ResteasyModule`` and bootstrap all the configurations needed for resteasy.
   In your ``ResteasyContextListener`` class install your service module and ``ResteasyBootstrapModule``.
 

--- a/docs/source/guides/troubleshooting.rst
+++ b/docs/source/guides/troubleshooting.rst
@@ -36,3 +36,19 @@ Problem
   What this usually telling you is that you have a scala version mismatch (Scala classes from 2.10 and 2.11 or 2.11 and 2.12 etc.).
   The best way we have found to resolve these inconsistencies is to do `mvn dependency:tree -Dincludes:scala-library::` and search
   the output for anything containing the unwanted version of Scala. For instance `scalatest_2.10` if you were using ``Scala 2.11``.
+
+
+Swagger
+----------------
+
+I am seeing resources from clients being treated as service resource by swagger
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Problem
+  Beadledom clients are automatically generated from an API resources annotated with swagger and JAX-RS annotations.
+  API definitions from clients used in a service is getting merged with the service definition.
+
+Suggested solution
+  Make your service module a private module, and expose only your resources. In another module install ``ResteasyModule`` and bootstrap all the configurations needed for resteasy.
+  In your ``ResteasyContextListener`` class install your service module and ``ResteasyBootstrapModule``.
+


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Changes to archetype and getting started doc for best practices around services.
* Archetype:
  * Created a new `ResteasyBootstrapModule` to bootstrap resteasy configuration.
  * The service module extends from privateModule and exposes on the service resource.
  * The contextlistener class installs the private ServiceModule and the abstract ResteasyBootstrapModule
* updated the getting started doc to reflect the above changes. 

How was it tested?
----

locally, by running the archetype and making sure that the service that is generated works.

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [x] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
