### PR TITLE
Adding SCM Version in health check page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Beadledom Changelog
 
 ## 2.4 - In Development
+* Added SCM Revision to health check.
 
 ### Defects Corrected
 * Removed unnecessary loop in `ResteasyContextListener` which would cause infinite loop if run.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * Brian van de Boogaard [@b-boogaard][brian-boogaard]
 * Supriya Lal [@lal-s][supriya-lal]
 * Jason Gassel [@jpeg][jason-gassel]
+* Rajkumar TS [@rajkumarts][rajkumar-ts]
 
 [john-leacox]: https://github.com/johnlcox
 [jacob-williams]: https://github.com/brokensandals
@@ -21,3 +22,4 @@
 [brian-boogaard]: https://github.com/b-boogaard
 [supriya-lal]: https://github.com/lal-s
 [jason-gassel]: https://github.com/jpeg
+[rajkumar-ts]: https://github.com/rajkumarts

--- a/health/api/src/main/java/com/cerner/beadledom/health/dto/BuildDto.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/dto/BuildDto.java
@@ -1,7 +1,6 @@
 package com.cerner.beadledom.health.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonView;
 import com.google.auto.value.AutoValue;
 import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
@@ -25,7 +24,8 @@ public abstract class BuildDto {
     return new AutoValue_BuildDto.Builder()
         .setArtifactName(Optional.empty())
         .setBuildDateTime(Optional.empty())
-        .setVersion(Optional.empty());
+        .setVersion(Optional.empty())
+        .setScmRevision(Optional.empty());
   }
 
   @ApiModelProperty("The name of the artifact")
@@ -39,6 +39,10 @@ public abstract class BuildDto {
   @ApiModelProperty("The build date/time of the service or application in ISO-8601 format")
   @JsonProperty("buildDateTime")
   public abstract Optional<String> getBuildDateTime();
+
+  @ApiModelProperty("The SCM version of the service which served this health check response")
+  @JsonProperty("scmRevision")
+  public abstract Optional<String> getScmRevision();
 
   @AutoValue.Builder
   public abstract static class Builder {
@@ -59,6 +63,12 @@ public abstract class BuildDto {
 
     public Builder setBuildDateTime(String buildDateTime) {
       return setBuildDateTime(Optional.ofNullable(buildDateTime));
+    }
+
+    abstract Builder setScmRevision(Optional<String> scmRevision);
+
+    public Builder setScmRevision(String scmRevision) {
+      return setScmRevision(Optional.ofNullable(scmRevision));
     }
 
     public abstract BuildDto build();

--- a/health/api/src/main/java/com/cerner/beadledom/health/dto/HealthDto.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/dto/HealthDto.java
@@ -56,6 +56,7 @@ public abstract class HealthDto {
         .setArtifactName(serviceMetadata.getBuildInfo().getArtifactId())
         .setVersion(serviceMetadata.getBuildInfo().getVersion())
         .setBuildDateTime(serviceMetadata.getBuildInfo().getBuildDateTime())
+        .setScmRevision(serviceMetadata.getBuildInfo().getScmRevision())
         .build();
     return new AutoValue_HealthDto.Builder()
         .setServer(server)

--- a/health/service/src/main/java/com/cerner/beadledom/health/internal/presenter/BuildPresenter.java
+++ b/health/service/src/main/java/com/cerner/beadledom/health/internal/presenter/BuildPresenter.java
@@ -43,4 +43,11 @@ public class BuildPresenter {
   public String getBuildDateTime() {
     return buildInfo.getBuildDateTime().map(buildDateTime -> buildDateTime).orElse("Not Available");
   }
+
+  /**
+   * Returns the scm version from the DTO.
+   */
+  public Optional<String> getScmRevision() {
+    return buildInfo.getScmRevision();
+  }
 }

--- a/health/service/src/main/resources/com/cerner/beadledom/health/diagnostic_health.mustache
+++ b/health/service/src/main/resources/com/cerner/beadledom/health/diagnostic_health.mustache
@@ -39,6 +39,8 @@
   {{#buildInfo}}
     <dt>Version</dt>
     <dd>{{version}}</dd>
+    <dt>SCM Version</dt>
+    <dd>{{scmRevision}}</dd>
   {{/buildInfo}}
 </dl>
 

--- a/resteasy/src/test/resources/com/cerner/beadledom/resteasy/expected/api-docs-health.json
+++ b/resteasy/src/test/resources/com/cerner/beadledom/resteasy/expected/api-docs-health.json
@@ -267,6 +267,10 @@
         "buildDateTime": {
           "type": "string",
           "description": "The build date/time of the service or application in ISO-8601 format"
+        },
+        "scmRevision": {
+          "type": "string",
+          "description": "The SCM version of the service which served this health check response"
         }
       }
     }

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
@@ -170,6 +170,7 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           "build" -> Json.obj(
             "artifactName" -> "faux-service",
             "version" -> "0.0.1-alpha",
+            "scmRevision" -> "abcde",
             "buildDateTime" -> "2016-07-29T06:12:33-05:00"
           )
         )


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------
https://github.com/cerner/beadledom/issues/20

* Added the SCM Version to health check. In development environment many developers deploy their own version of services. This field will be helpful in identifying which scm version of the service is deployed. 


How was it tested?
----

* Unit tests. Also consumed this snapshot version in our project to make sure the correct scm version is displayed. 


How to test
----

* Consume this version in any of the services that uses beadledom health and check the 
`{service-url}/meta/health/diagnostic`.

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
