### PR TITLE
Fixed BeadledomClientBuilderProvider using wrong injector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 * Removed unnecessary loop in `ResteasyContextListener` which would cause infinite loop if run.
 * Fixed issue with redirects in the bootstrap script ([issue-15](https://github.com/cerner/beadledom/issues/15)).
 * WebApplicationException mapper is called when exceptions are thrown by the checkParam method in JaxRsParamConditions class ([#16](https://github.com/cerner/beadledom/pull/16)).
-* Fixed BeadledomClientBuilderProvider using root Guice injector instead of nearest child injector.
+* Fixed `BeadledomClientBuilderProvider` using root Guice injector instead of nearest child injector.
 
-## 2.3 - 24 01 2017
+## 2.3 - 24 Jan 2017
 
 ### Enhancements
 * Fixed resteasy [compatibility issues](https://github.com/cerner/beadledom/issues/9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Removed unnecessary loop in `ResteasyContextListener` which would cause infinite loop if run.
 * Fixed issue with redirects in the bootstrap script ([issue-15](https://github.com/cerner/beadledom/issues/15)).
 * WebApplicationException mapper is called when exceptions are thrown by the checkParam method in JaxRsParamConditions class ([#16](https://github.com/cerner/beadledom/pull/16)).
+* Fixed BeadledomClientBuilderProvider using root Guice injector instead of nearest child injector.
 
 ## 2.3 - 24 01 2017
 

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderProvider.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderProvider.java
@@ -36,7 +36,7 @@ class BeadledomClientBuilderProvider implements Provider<BeadledomClientBuilder>
       BeadledomClientBuilder.class,
       BeadledomClientLifecycleHook.class);
 
-  private Provider<Injector> injectorProvider;
+  private Injector injector;
   private String correlationIdHeader;
 
   BeadledomClientBuilderProvider(Class<? extends Annotation> clientBindingAnnotation) {
@@ -45,11 +45,11 @@ class BeadledomClientBuilderProvider implements Provider<BeadledomClientBuilder>
 
   @Inject
   void init(
-      Provider<Injector> injectorProvider,
+      Injector injector,
       @CorrelationIdClientHeader String correlationIdHeaderOpt,
       DynamicBindingProvider<Optional<BeadledomClientConfiguration>> beadledomConfigProvider,
       DynamicBindingProvider<BeadledomClientBuilderFactory> clientBuilderFactoryProvider) {
-    this.injectorProvider = injectorProvider;
+    this.injector = injector;
     this.correlationIdHeader = correlationIdHeaderOpt;
     this.beadledomConfigProvider = beadledomConfigProvider;
     this.clientBuilderFactoryProvider = clientBuilderFactoryProvider;
@@ -84,13 +84,17 @@ class BeadledomClientBuilderProvider implements Provider<BeadledomClientBuilder>
       }
     }
 
-    Injector injector = injectorProvider.get();
-    processInjector(injector, clientBuilder);
-    while (injector.getParent() != null) {
-      injector = injector.getParent();
-      processInjector(injector, clientBuilder);
+    Injector tempInjector = getInjector();
+    processInjector(tempInjector, clientBuilder);
+    while (tempInjector.getParent() != null) {
+      tempInjector = tempInjector.getParent();
+      processInjector(tempInjector, clientBuilder);
     }
     return clientBuilder;
+  }
+
+  private Injector getInjector() {
+    return injector;
   }
 
   private void processInjector(Injector injector, BeadledomClientBuilder builder) {

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientPrivateModule.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientPrivateModule.java
@@ -78,7 +78,8 @@ class BeadledomClientPrivateModule extends AnnotatedModule {
         new BeadledomClientBuilderProvider(getBindingAnnotation());
 
     bind(BeadledomClientBuilder.class).annotatedWith(getBindingAnnotation())
-        .toProvider(beadledomClientBuilderProvider);
+        .toProvider(beadledomClientBuilderProvider)
+        .asEagerSingleton();
 
     bindDynamicProvider(BeadledomClientBuilder.class);
 


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

`BeadledomClientBuilderProvider` was using a `Provider<Injector>` to get an instance of a Guice `Injector`. Since the provider defers getting an instance of an `Injector` until the provider is actually used, the context private module child Injectors is lost by the time an instance is retrieved. This provider should be using the nearest child injector from the private modules the client is being configured in. Changing the class to take an instance of `Injector` directly instead of a provider directly makes the injection more eager and results in the correct child injector being used.


How was it tested?
----

Additional unit test.

How to test
----

- [ ] `mvn clean install -U`

Reviewers
----

- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [x] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
