### PR TITLE
Add chained build method to generic response docs

### DIFF
--- a/docs/source/manual/jaxrs_generic_response.rst
+++ b/docs/source/manual/jaxrs_generic_response.rst
@@ -28,7 +28,7 @@ From the server side a ``GenericResponse`` can be created through the ``GenericR
 
 .. code-block:: java
 
-  return GenericResponses.ok(entityBody);
+  return GenericResponses.ok(entityBody).build();
 
 From the client side the entity body can be retrieve from a ``GenericResponse`` through the ``body`` method.
 


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Corrected the generic response docs to show that `build` is required to get an instance of the `GenericRespone`.


How was it tested?
----

n/a


How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [x] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [x] [Brian van de Boogaard](https://github.com/b-boogaard)
