### PR TITLE
Added toString implementation to DelegatingGenericResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Defects Corrected
  * Cleaned up dependencies and fixed few minor issues with generated code in archetype 
 
+### Enhancements
+ * Added toString implementation to DelegatingGenericResponse
+
 ## 2.4 - 16 Feb 2017
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
  * Cleaned up dependencies and fixed few minor issues with generated code in archetype 
 
 ### Enhancements
- * Added toString implementation to DelegatingGenericResponse
+ * Added toString implementation to DelegatingGenericResponse and BuiltGenericResponse
 
 ## 2.4 - 16 Feb 2017
 

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
@@ -25,6 +25,7 @@ public class DelegatingGenericResponse<T> extends Response implements GenericRes
   private final T body;
   private final Class<?> bodyClass;
   private final ErrorBody errorBody;
+
   private final Response rawResponse;
 
   /**
@@ -249,5 +250,16 @@ public class DelegatingGenericResponse<T> extends Response implements GenericRes
   @Override
   public String getHeaderString(String name) {
     return rawResponse.getHeaderString(name);
+  }
+
+  @Override
+  public String toString() {
+    return "DelegatingGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
+            + ", rawResponse=Response{status=" + rawResponse.getStatus() + ", mediaType="
+            + rawResponse.getMediaType() + ", date=" + rawResponse.getDate() + ", length=" + rawResponse.getLength()
+            + ", lastModified=" + rawResponse.getLastModified() + ", entityTag=" + rawResponse.getEntityTag()
+            + ", language=" + rawResponse.getLanguage() + ", location=" + rawResponse.getLocation()
+            + ", headers=" + rawResponse.getHeaders() + ", cookies=" + rawResponse.getCookies() + ", links="
+            + rawResponse.getLinks() + " } }";
   }
 }

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
@@ -254,6 +254,6 @@ public class DelegatingGenericResponse<T> extends Response implements GenericRes
   @Override
   public String toString() {
     return "DelegatingGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
-            + ", rawResponse=" + ResponseToStringWrapper.toString(rawResponse) + " }";
+            + ", rawResponse=" + new ResponseToStringWrapper(rawResponse) + " }";
   }
 }

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
@@ -254,11 +254,6 @@ public class DelegatingGenericResponse<T> extends Response implements GenericRes
   @Override
   public String toString() {
     return "DelegatingGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
-            + ", rawResponse=Response{status=" + rawResponse.getStatus() + ", mediaType="
-            + rawResponse.getMediaType() + ", date=" + rawResponse.getDate() + ", length=" + rawResponse.getLength()
-            + ", lastModified=" + rawResponse.getLastModified() + ", entityTag=" + rawResponse.getEntityTag()
-            + ", language=" + rawResponse.getLanguage() + ", location=" + rawResponse.getLocation()
-            + ", headers=" + rawResponse.getHeaders() + ", cookies=" + rawResponse.getCookies() + ", links="
-            + rawResponse.getLinks() + " } }";
+            + ", rawResponse=" + ResponseToStringWrapper.toString(rawResponse) +" }";
   }
 }

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
@@ -25,7 +25,6 @@ public class DelegatingGenericResponse<T> extends Response implements GenericRes
   private final T body;
   private final Class<?> bodyClass;
   private final ErrorBody errorBody;
-
   private final Response rawResponse;
 
   /**

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/DelegatingGenericResponse.java
@@ -254,6 +254,6 @@ public class DelegatingGenericResponse<T> extends Response implements GenericRes
   @Override
   public String toString() {
     return "DelegatingGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
-            + ", rawResponse=" + ResponseToStringWrapper.toString(rawResponse) +" }";
+            + ", rawResponse=" + ResponseToStringWrapper.toString(rawResponse) + " }";
   }
 }

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/ResponseToStringWrapper.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/ResponseToStringWrapper.java
@@ -3,18 +3,27 @@ package com.cerner.beadledom.jaxrs;
 import javax.ws.rs.core.Response;
 
 /**
- * Simple class to implement {@link Response} to String.
+ * Simple class that wraps {@link Response} and implements {@link #toString()} for {@link Response}.
  */
 public class ResponseToStringWrapper {
 
+  private final Response response;
+
   /**
-   * Converts {@link Response} to String.
+   * Constructs the wrapper.
    *
    * @param response
-   *      the {@link Response} to convert
-   * @return {@link Response} as a String
+   *    the response to wrap
    */
-  public static String toString(Response response) {
+  public ResponseToStringWrapper(Response response) {
+    if (response == null) {
+      throw new NullPointerException("response:null");
+    }
+    this.response = response;
+  }
+
+  @Override
+  public String toString() {
     return "Response{status=" + response.getStatus() + ", mediaType="
       + response.getMediaType() + ", date=" + response.getDate() + ", length=" + response.getLength()
       + ", lastModified=" + response.getLastModified() + ", entityTag=" + response.getEntityTag()

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/ResponseToStringWrapper.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/ResponseToStringWrapper.java
@@ -3,23 +3,24 @@ package com.cerner.beadledom.jaxrs;
 import javax.ws.rs.core.Response;
 
 /**
- * Simple class to implement {@link Response} to String
+ * Simple class to implement {@link Response} to String.
  */
 public class ResponseToStringWrapper {
 
-    /**
-     * Converts {@link Response} to String
-     *
-     * @param response
-     *      the {@link Response} to convert
-     * @return {@link Response} as a String
-     */
-    public static String toString(Response response) {
-        return "Response{status=" + response.getStatus() + ", mediaType="
-                + response.getMediaType() + ", date=" + response.getDate() + ", length=" + response.getLength()
-                + ", lastModified=" + response.getLastModified() + ", entityTag=" + response.getEntityTag()
-                + ", language=" + response.getLanguage() + ", location=" + response.getLocation()
-                + ", headers=" + response.getHeaders() + ", cookies=" + response.getCookies() + ", links="
-                + response.getLinks() + " }";
-    }
+  /**
+   * Converts {@link Response} to String.
+   *
+   * @param response
+   *      the {@link Response} to convert
+   * @return {@link Response} as a String
+   */
+  public static String toString(Response response) {
+    return "Response{status=" + response.getStatus() + ", mediaType="
+      + response.getMediaType() + ", date=" + response.getDate() + ", length=" + response.getLength()
+      + ", lastModified=" + response.getLastModified() + ", entityTag=" + response.getEntityTag()
+      + ", language=" + response.getLanguage() + ", location=" + response.getLocation()
+      + ", headers=" + response.getHeaders() + ", cookies=" + response.getCookies() + ", links="
+      + response.getLinks() + " }";
+  }
+
 }

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/ResponseToStringWrapper.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/ResponseToStringWrapper.java
@@ -1,0 +1,25 @@
+package com.cerner.beadledom.jaxrs;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Simple class to implement {@link Response} to String
+ */
+public class ResponseToStringWrapper {
+
+    /**
+     * Converts {@link Response} to String
+     *
+     * @param response
+     *      the {@link Response} to convert
+     * @return {@link Response} as a String
+     */
+    public static String toString(Response response) {
+        return "Response{status=" + response.getStatus() + ", mediaType="
+                + response.getMediaType() + ", date=" + response.getDate() + ", length=" + response.getLength()
+                + ", lastModified=" + response.getLastModified() + ", entityTag=" + response.getEntityTag()
+                + ", language=" + response.getLanguage() + ", location=" + response.getLocation()
+                + ", headers=" + response.getHeaders() + ", cookies=" + response.getCookies() + ", links="
+                + response.getLinks() + " }";
+    }
+}

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/DelegatingGenericResponseSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/DelegatingGenericResponseSpec.scala
@@ -2,7 +2,11 @@ package com.cerner.beadledom.jaxrs
 
 import com.cerner.beadledom.testing.UnitSpec
 import java.lang.annotation.Annotation
-import javax.ws.rs.core.{GenericType, Response}
+import java.net.URI
+import java.util
+import java.util.{Collections, Date, Locale}
+import javax.ws.rs.core._
+
 import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.mock.MockitoSugar
@@ -435,5 +439,31 @@ class DelegatingGenericResponseSpec
         verify(rawResponse).getHeaderString("header")
       }
     }
+
+    describe("#toString") {
+      it("returns String with all fields included") {
+        val rawResponse = mock[Response]
+        when(rawResponse.getStatus).thenReturn(200)
+        when(rawResponse.getMediaType).thenReturn(MediaType.APPLICATION_JSON_TYPE)
+        when(rawResponse.getDate).thenReturn(new Date(0L))
+        when(rawResponse.getLength).thenReturn(123)
+        when(rawResponse.getLastModified).thenReturn(new Date(0L))
+        when(rawResponse.getEntityTag).thenReturn(new EntityTag("tag-value"))
+        when(rawResponse.getLanguage).thenReturn(Locale.ENGLISH)
+        when(rawResponse.getLocation).thenReturn(new URI("http://localhost"))
+        val headers  = new MultivaluedHashMap[String, Object]()
+        headers.put("header-key", util.Arrays.asList("header-value"))
+        when(rawResponse.getHeaders).thenReturn(headers)
+        when(rawResponse.getCookies).thenReturn(Collections.singletonMap("my-cookie", new NewCookie("key", "value")))
+        when(rawResponse.getLinks).thenReturn(new util.HashSet[Link]())
+
+        DelegatingGenericResponse.create("Hello World", rawResponse).toString mustBe
+          """DelegatingGenericResponse{body=Hello World, bodyClass=class java.lang.String, errorBody=null,
+             |rawResponse=Response{status=200, mediaType=application/json, date=Wed Dec 31 18:00:00 CST 1969, length=123,
+             |lastModified=Wed Dec 31 18:00:00 CST 1969, entityTag="tag-value", language=en, location=http://localhost,
+             |headers={header-key=[header-value]}, cookies={my-cookie=key=value;Version=1}, links=[] } }""".stripMargin.replaceAll("\n", " ")
+      }
+    }
+
   }
 }

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/DelegatingGenericResponseSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/DelegatingGenericResponseSpec.scala
@@ -443,11 +443,13 @@ class DelegatingGenericResponseSpec
     describe("#toString") {
       it("returns String with all fields included") {
         val rawResponse = mock[Response]
+        val date = new Date(0L)
+
         when(rawResponse.getStatus).thenReturn(200)
         when(rawResponse.getMediaType).thenReturn(MediaType.APPLICATION_JSON_TYPE)
-        when(rawResponse.getDate).thenReturn(new Date(0L))
+        when(rawResponse.getDate).thenReturn(date)
         when(rawResponse.getLength).thenReturn(123)
-        when(rawResponse.getLastModified).thenReturn(new Date(0L))
+        when(rawResponse.getLastModified).thenReturn(date)
         when(rawResponse.getEntityTag).thenReturn(new EntityTag("tag-value"))
         when(rawResponse.getLanguage).thenReturn(Locale.ENGLISH)
         when(rawResponse.getLocation).thenReturn(new URI("http://localhost"))
@@ -458,9 +460,9 @@ class DelegatingGenericResponseSpec
         when(rawResponse.getLinks).thenReturn(new util.HashSet[Link]())
 
         DelegatingGenericResponse.create("Hello World", rawResponse).toString mustBe
-          """DelegatingGenericResponse{body=Hello World, bodyClass=class java.lang.String, errorBody=null,
-             |rawResponse=Response{status=200, mediaType=application/json, date=Wed Dec 31 18:00:00 CST 1969, length=123,
-             |lastModified=Wed Dec 31 18:00:00 CST 1969, entityTag="tag-value", language=en, location=http://localhost,
+          s"""DelegatingGenericResponse{body=Hello World, bodyClass=class java.lang.String, errorBody=null,
+             |rawResponse=Response{status=200, mediaType=application/json, date=$date, length=123,
+             |lastModified=$date, entityTag="tag-value", language=en, location=http://localhost,
              |headers={header-key=[header-value]}, cookies={my-cookie=key=value;Version=1}, links=[] } }""".stripMargin.replaceAll("\n", " ")
       }
     }

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/ResponseToStringWrapperSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/ResponseToStringWrapperSpec.scala
@@ -1,0 +1,41 @@
+package com.cerner.beadledom.jaxrs
+
+
+import java.net.URI
+import java.util
+import java.util.{Collections, Date, Locale}
+import javax.ws.rs.core._
+
+import com.cerner.beadledom.testing.UnitSpec
+import org.mockito.Mockito.when
+import org.scalatest.mock.MockitoSugar
+
+class ResponseToStringWrapperSpec extends UnitSpec with MockitoSugar {
+  describe("ResponseToStringWrapper") {
+
+    describe("#toString") {
+      it("includes all Response values in String") {
+        val rawResponse = mock[Response]
+        when(rawResponse.getStatus).thenReturn(200)
+        when(rawResponse.getMediaType).thenReturn(MediaType.APPLICATION_JSON_TYPE)
+        when(rawResponse.getDate).thenReturn(new Date(0L))
+        when(rawResponse.getLength).thenReturn(123)
+        when(rawResponse.getLastModified).thenReturn(new Date(0L))
+        when(rawResponse.getEntityTag).thenReturn(new EntityTag("tag-value"))
+        when(rawResponse.getLanguage).thenReturn(Locale.ENGLISH)
+        when(rawResponse.getLocation).thenReturn(new URI("http://localhost"))
+        val headers  = new MultivaluedHashMap[String, Object]()
+        headers.put("header-key", util.Arrays.asList("header-value"))
+        when(rawResponse.getHeaders).thenReturn(headers)
+        when(rawResponse.getCookies).thenReturn(Collections.singletonMap("my-cookie", new NewCookie("key", "value")))
+        when(rawResponse.getLinks).thenReturn(new util.HashSet[Link]())
+
+        new ResponseToStringWrapper(rawResponse).toString mustBe
+        """Response{status=200, mediaType=application/json, date=Wed Dec 31 18:00:00 CST 1969, length=123,
+          |lastModified=Wed Dec 31 18:00:00 CST 1969, entityTag="tag-value", language=en, location=http://localhost,
+          |headers={header-key=[header-value]}, cookies={my-cookie=key=value;Version=1}, links=[] }""".stripMargin.replaceAll("\n", " ")
+      }
+    }
+
+  }
+}

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/ResponseToStringWrapperSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/ResponseToStringWrapperSpec.scala
@@ -16,11 +16,13 @@ class ResponseToStringWrapperSpec extends UnitSpec with MockitoSugar {
     describe("#toString") {
       it("includes all Response values in String") {
         val rawResponse = mock[Response]
+        val date = new Date(0L)
+
         when(rawResponse.getStatus).thenReturn(200)
         when(rawResponse.getMediaType).thenReturn(MediaType.APPLICATION_JSON_TYPE)
-        when(rawResponse.getDate).thenReturn(new Date(0L))
+        when(rawResponse.getDate).thenReturn(date)
         when(rawResponse.getLength).thenReturn(123)
-        when(rawResponse.getLastModified).thenReturn(new Date(0L))
+        when(rawResponse.getLastModified).thenReturn(date)
         when(rawResponse.getEntityTag).thenReturn(new EntityTag("tag-value"))
         when(rawResponse.getLanguage).thenReturn(Locale.ENGLISH)
         when(rawResponse.getLocation).thenReturn(new URI("http://localhost"))
@@ -31,8 +33,8 @@ class ResponseToStringWrapperSpec extends UnitSpec with MockitoSugar {
         when(rawResponse.getLinks).thenReturn(new util.HashSet[Link]())
 
         new ResponseToStringWrapper(rawResponse).toString mustBe
-        """Response{status=200, mediaType=application/json, date=Wed Dec 31 18:00:00 CST 1969, length=123,
-          |lastModified=Wed Dec 31 18:00:00 CST 1969, entityTag="tag-value", language=en, location=http://localhost,
+        s"""Response{status=200, mediaType=application/json, date=$date, length=123,
+          |lastModified=$date, entityTag="tag-value", language=en, location=http://localhost,
           |headers={header-key=[header-value]}, cookies={my-cookie=key=value;Version=1}, links=[] }""".stripMargin.replaceAll("\n", " ")
       }
     }

--- a/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
+++ b/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
@@ -34,6 +34,7 @@ import org.jboss.resteasy.specimpl.BuiltResponse;
 public class BuiltGenericResponse<T> extends BuiltResponse implements GenericResponse<T> {
   private final T body;
   private final Class<?> bodyClass;
+
   private final ErrorBody errorBody;
   private final Response rawResponse;
 
@@ -254,5 +255,16 @@ public class BuiltGenericResponse<T> extends BuiltResponse implements GenericRes
   @Override
   public String getHeaderString(String name) {
     return rawResponse.getHeaderString(name);
+  }
+
+  @Override
+  public String toString() {
+    return "BuiltGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
+            + ", rawResponse=Response{status=" + rawResponse.getStatus() + ", mediaType="
+            + rawResponse.getMediaType() + ", date=" + rawResponse.getDate() + ", length=" + rawResponse.getLength()
+            + ", lastModified=" + rawResponse.getLastModified() + ", entityTag=" + rawResponse.getEntityTag()
+            + ", language=" + rawResponse.getLanguage() + ", location=" + rawResponse.getLocation()
+            + ", headers=" + rawResponse.getHeaders() + ", cookies=" + rawResponse.getCookies() + ", links="
+            + rawResponse.getLinks() + " } }";
   }
 }

--- a/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
+++ b/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
@@ -16,6 +16,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
+
+import com.cerner.beadledom.jaxrs.ResponseToStringWrapper;
 import org.jboss.resteasy.specimpl.BuiltResponse;
 
 /**
@@ -260,11 +262,6 @@ public class BuiltGenericResponse<T> extends BuiltResponse implements GenericRes
   @Override
   public String toString() {
     return "BuiltGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
-            + ", rawResponse=Response{status=" + rawResponse.getStatus() + ", mediaType="
-            + rawResponse.getMediaType() + ", date=" + rawResponse.getDate() + ", length=" + rawResponse.getLength()
-            + ", lastModified=" + rawResponse.getLastModified() + ", entityTag=" + rawResponse.getEntityTag()
-            + ", language=" + rawResponse.getLanguage() + ", location=" + rawResponse.getLocation()
-            + ", headers=" + rawResponse.getHeaders() + ", cookies=" + rawResponse.getCookies() + ", links="
-            + rawResponse.getLinks() + " } }";
+            + ", rawResponse=" + ResponseToStringWrapper.toString(rawResponse) + " }";
   }
 }

--- a/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
+++ b/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
@@ -262,6 +262,6 @@ public class BuiltGenericResponse<T> extends BuiltResponse implements GenericRes
   @Override
   public String toString() {
     return "BuiltGenericResponse{body=" + body + ", bodyClass=" + bodyClass + ", errorBody=" + errorBody
-            + ", rawResponse=" + ResponseToStringWrapper.toString(rawResponse) + " }";
+            + ", rawResponse=" + new ResponseToStringWrapper(rawResponse) + " }";
   }
 }

--- a/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
+++ b/resteasy-genericresponse/src/main/java/com/cerner/beadledom/resteasy/BuiltGenericResponse.java
@@ -2,6 +2,7 @@ package com.cerner.beadledom.resteasy;
 
 import com.cerner.beadledom.jaxrs.ErrorBody;
 import com.cerner.beadledom.jaxrs.GenericResponse;
+import com.cerner.beadledom.jaxrs.ResponseToStringWrapper;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URI;
@@ -17,7 +18,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
-import com.cerner.beadledom.jaxrs.ResponseToStringWrapper;
 import org.jboss.resteasy.specimpl.BuiltResponse;
 
 /**

--- a/resteasy-genericresponse/src/test/scala/com/cerner/beadledom/resteasy/BuiltGenericResponseSpec.scala
+++ b/resteasy-genericresponse/src/test/scala/com/cerner/beadledom/resteasy/BuiltGenericResponseSpec.scala
@@ -444,11 +444,13 @@ class BuiltGenericResponseSpec
     describe("#toString") {
       it("returns String with all fields included") {
         val rawResponse = mock[Response]
+        val date = new Date(0L)
+
         when(rawResponse.getStatus).thenReturn(200)
         when(rawResponse.getMediaType).thenReturn(MediaType.APPLICATION_JSON_TYPE)
-        when(rawResponse.getDate).thenReturn(new Date(0L))
+        when(rawResponse.getDate).thenReturn(date)
         when(rawResponse.getLength).thenReturn(123)
-        when(rawResponse.getLastModified).thenReturn(new Date(0L))
+        when(rawResponse.getLastModified).thenReturn(date)
         when(rawResponse.getEntityTag).thenReturn(new EntityTag("tag-value"))
         when(rawResponse.getLanguage).thenReturn(Locale.ENGLISH)
         when(rawResponse.getLocation).thenReturn(new URI("http://localhost"))
@@ -459,9 +461,9 @@ class BuiltGenericResponseSpec
         when(rawResponse.getLinks).thenReturn(new util.HashSet[Link]())
 
         BuiltGenericResponse.create("Hello World", rawResponse).toString mustBe
-          """BuiltGenericResponse{body=Hello World, bodyClass=class java.lang.String, errorBody=null,
-            |rawResponse=Response{status=200, mediaType=application/json, date=Wed Dec 31 18:00:00 CST 1969, length=123,
-            |lastModified=Wed Dec 31 18:00:00 CST 1969, entityTag="tag-value", language=en, location=http://localhost,
+          s"""BuiltGenericResponse{body=Hello World, bodyClass=class java.lang.String, errorBody=null,
+            |rawResponse=Response{status=200, mediaType=application/json, date=$date, length=123,
+            |lastModified=$date, entityTag="tag-value", language=en, location=http://localhost,
             |headers={header-key=[header-value]}, cookies={my-cookie=key=value;Version=1}, links=[] } }""".stripMargin.replaceAll("\n", " ")
       }
     }

--- a/resteasy-genericresponse/src/test/scala/com/cerner/beadledom/resteasy/BuiltGenericResponseSpec.scala
+++ b/resteasy-genericresponse/src/test/scala/com/cerner/beadledom/resteasy/BuiltGenericResponseSpec.scala
@@ -3,7 +3,11 @@ package com.cerner.beadledom.resteasy
 import com.cerner.beadledom.jaxrs.{DelegatingGenericResponse, GenericResponse}
 import com.cerner.beadledom.testing.UnitSpec
 import java.lang.annotation.Annotation
-import javax.ws.rs.core.{GenericType, Response}
+import java.net.URI
+import java.util
+import java.util.{Collections, Date, Locale}
+import javax.ws.rs.core._
+
 import org.mockito.Mockito._
 import org.scalacheck.Gen
 import org.scalatest.mock.MockitoSugar
@@ -434,6 +438,31 @@ class BuiltGenericResponseSpec
 
         response.getHeaderString("header")
         verify(rawResponse).getHeaderString("header")
+      }
+    }
+
+    describe("#toString") {
+      it("returns String with all fields included") {
+        val rawResponse = mock[Response]
+        when(rawResponse.getStatus).thenReturn(200)
+        when(rawResponse.getMediaType).thenReturn(MediaType.APPLICATION_JSON_TYPE)
+        when(rawResponse.getDate).thenReturn(new Date(0L))
+        when(rawResponse.getLength).thenReturn(123)
+        when(rawResponse.getLastModified).thenReturn(new Date(0L))
+        when(rawResponse.getEntityTag).thenReturn(new EntityTag("tag-value"))
+        when(rawResponse.getLanguage).thenReturn(Locale.ENGLISH)
+        when(rawResponse.getLocation).thenReturn(new URI("http://localhost"))
+        val headers  = new MultivaluedHashMap[String, Object]()
+        headers.put("header-key", util.Arrays.asList("header-value"))
+        when(rawResponse.getHeaders).thenReturn(headers)
+        when(rawResponse.getCookies).thenReturn(Collections.singletonMap("my-cookie", new NewCookie("key", "value")))
+        when(rawResponse.getLinks).thenReturn(new util.HashSet[Link]())
+
+        BuiltGenericResponse.create("Hello World", rawResponse).toString mustBe
+          """BuiltGenericResponse{body=Hello World, bodyClass=class java.lang.String, errorBody=null,
+            |rawResponse=Response{status=200, mediaType=application/json, date=Wed Dec 31 18:00:00 CST 1969, length=123,
+            |lastModified=Wed Dec 31 18:00:00 CST 1969, entityTag="tag-value", language=en, location=http://localhost,
+            |headers={header-key=[header-value]}, cookies={my-cookie=key=value;Version=1}, links=[] } }""".stripMargin.replaceAll("\n", " ")
       }
     }
   }


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Dumb but nice to have, added toString implementation to help testing and debugging. 

I originally did this while playing around with the client and implemented it on what the client sees (DelegatingGenericResponse) but I'm thinking this should instead be implemented on the interface (GenericResponse) instead otherwise you would likely want to implement toString on BuiltGenericResponse to be consistent. Let me know if you have a preference.

I also effectively implemented toString for raw Response otherwise you just get a reference to ApacheHttpClient4Dot3Engine on the client side and from what I can tell BuiltResponse on server side. I can't decide if I should try to provide a pull to resteasy to implement toString for those classes or just leave it here. Again let me know if you have a preference.

How was it tested?
----

Built locally and ran with a client implementation

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [x] [John Leacox](https://github.com/johnlcox)
- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [x] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
