### PR TITLE
Fix dependency version issue in archetype

### DIFF
--- a/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
@@ -82,6 +82,11 @@
                 <version>2.0.2</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>15.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>${guice.version}</version>
@@ -125,6 +130,11 @@
                 <groupId>com.wordnik</groupId>
                 <artifactId>swagger-core_${scala.binary.version}</artifactId>
                 <version>${swagger-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.inject</groupId>
+                <artifactId>javax.inject</artifactId>
+                <version>1</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Add the dependency version for guava and javax to the parent pom of the archetype


How was it tested?
----

Generate a service through archetype and running it successfully


How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [x] [John Leacox](https://github.com/johnlcox)
- [x] [Sundeep Paruvu](https://github.com/sparuvu)
- [x] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
