### PR TITLE
Fix checkstyle plugin to run again

### DIFF
--- a/avro/jackson/src/main/java/com/cerner/beadledom/avro/AvroJacksonGuiceModule.java
+++ b/avro/jackson/src/main/java/com/cerner/beadledom/avro/AvroJacksonGuiceModule.java
@@ -10,7 +10,7 @@ import com.google.inject.multibindings.MultibindingsScanner;
  *
  * <p>Provides:
  * <ul>
- *     <li>Avro serialization support for Jackson via {@link Multibinder&lt;Module&gt;}</li>
+ *     <li>Avro serialization support for Jackson via {@link Multibinder Multibinder&lt;Module&gt;}</li>
  * </ul>
  *
  * <p>Requires:

--- a/avro/swagger/src/main/java/com/cerner/beadledom/avro/AvroSwaggerGuiceModule.java
+++ b/avro/swagger/src/main/java/com/cerner/beadledom/avro/AvroSwaggerGuiceModule.java
@@ -10,7 +10,7 @@ import com.wordnik.swagger.converter.ModelConverter;
  *
  * <p>Provides:
  * <ul>
- *     <li>Avro serialization support for Swagger via {@link Multibinder&lt;ModelConvert&gt;}</li>
+ *     <li>Avro serialization support for Swagger via {@link Multibinder Multibinder&lt;ModelConverter&gt;}</li>
  * </ul>
  *
  * <p>Installs:

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientProvider.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientProvider.java
@@ -8,7 +8,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 /**
- * A Guice provider for {@link BeadledomClient}
+ * A Guice provider for {@link BeadledomClient}.
  *
  * @author Sundeep Paruvu
  * @since 2.0

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientConfiguration.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientConfiguration.java
@@ -1,8 +1,6 @@
 package com.cerner.beadledom.client;
 
-
 import com.google.auto.value.AutoValue;
-
 import java.security.KeyStore;
 import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;

--- a/google_checks_1.8.xml
+++ b/google_checks_1.8.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!--
 
@@ -58,9 +58,7 @@
                       value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>

--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/GenericResponseBuilder.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/GenericResponseBuilder.java
@@ -33,7 +33,7 @@ public abstract class GenericResponseBuilder<T> {
 
   /**
    * Creates a new {@link GenericResponseBuilder} that delegates to the underlying
-   * @code rawBuilder}.
+   * {@code rawBuilder}.
    */
   protected GenericResponseBuilder(Response.ResponseBuilder rawBuilder) {
     this.rawBuilder = rawBuilder;

--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,28 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.1</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <configLocation>google_checks_1.8.xml</configLocation>
+                    <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -729,32 +751,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.16</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>${maven-checkstyle-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>7.1</version>
-                        </dependency>
-                    </dependencies>
-                    <configuration>
-                        <configLocation>google_checks_1.8.xml</configLocation>
-                        <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
-                        <consoleOutput>true</consoleOutput>
-                        <failsOnError>true</failsOnError>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>checkstyle</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

The checkstyle configuration within the pluginManagement section of the
pom was not being used when running the plugin. To get the configuration
to be used, the plugin configuration was removed from pluginManagement
and moved directly to the plugin within the build section.

The checkstyle jar version was also upgraded to 8.1. 8.2 is the latest
version, but it seems to have a bug where it blows up on escaped html
tags like `&lt;` or `&gt;` within javadoc.


How was it tested?
----

Ran `mvn checkstyle:checkstyle` and `mvn clean install`

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
