### PR TITLE
Breaking up BeadledomModule 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Beadledom Changelog
 
+## 3.0 - 
+
+### Breaking Changes
+
+* Removes StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, and AvroSwaggerGuiceModule modules from being installed by BeadledomModule. If the 
+removed functionality is desired, install the removed modules in the consuming guice module.
+
 ## 2.6.1 - 22 September 2017
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Breaking Changes
 
-* Removes StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, and AvroSwaggerGuiceModule modules from being installed by BeadledomModule. If the 
-removed functionality is desired, install the removed modules in the consuming guice module.
+* Removes StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, and AvroSwaggerGuiceModule 
+modules from being installed by BeadledomModule. If the removed functionality is desired, install 
+the removed modules in the consuming guice module.
 
 ## 2.6.1 - 22 September 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Breaking Changes
 
-* Removes StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, and AvroSwaggerGuiceModule 
-modules from being installed by BeadledomModule. If the removed functionality is desired, install 
-the removed modules in the consuming guice module.
+* Removes StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, AvroSwaggerGuiceModule, and 
+HealthModule modules from being installed by BeadledomModule. If the removed functionality is 
+desired, install the removed modules in the consuming guice module.
 
 ## 2.6.1 - 22 September 2017
 

--- a/archetype/simple-service/src/main/resources/archetype-resources/api/src/main/java/api/HelloWorldResource.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/api/src/main/java/api/HelloWorldResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 @Api(value = "/hello", description = "Retrieve hello world data")
 @Path("/hello")

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/pom.xml
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>com.cerner.beadledom</groupId>
+            <artifactId>beadledom-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.cerner.beadledom</groupId>
             <artifactId>beadledom-jaxrs-genericresponse</artifactId>
         </dependency>
         <dependency>

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/pom.xml
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/pom.xml
@@ -38,6 +38,10 @@
         </dependency>
         <dependency>
             <groupId>com.cerner.beadledom</groupId>
+            <artifactId>beadledom-stagemonitor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.cerner.beadledom</groupId>
             <artifactId>beadledom-swagger</artifactId>
         </dependency>
         <dependency>

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
@@ -6,6 +6,8 @@ package ${package}.service;
 import com.cerner.beadledom.metadata.BuildInfo;
 import com.cerner.beadledom.metadata.ServiceMetadata;
 import com.cerner.beadledom.resteasy.ResteasyModule;
+import com.cerner.beadledom.stagemonitor.StagemonitorModule;
+import com.cerner.beadledom.swagger.SwaggerModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.wordnik.swagger.config.SwaggerConfig;
@@ -16,6 +18,7 @@ public class ResteasyBootstrapModule extends AbstractModule {
   protected void configure() {
     install(new ResteasyModule());
     install(new StagemonitorModule());
+    install(new SwaggerModule());
 
     BuildInfo buildInfo = BuildInfo.load(ResteasyBootstrapModule.class.getResourceAsStream("build-info.properties"));
     bind(BuildInfo.class).toInstance(buildInfo);

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
@@ -3,6 +3,7 @@
 #set( $symbol_escape = '\' )
 package ${package}.service;
 
+import com.cerner.beadledom.health.HealthModule;
 import com.cerner.beadledom.metadata.BuildInfo;
 import com.cerner.beadledom.metadata.ServiceMetadata;
 import com.cerner.beadledom.resteasy.ResteasyModule;
@@ -19,6 +20,7 @@ public class ResteasyBootstrapModule extends AbstractModule {
     install(new ResteasyModule());
     install(new StagemonitorModule());
     install(new SwaggerModule());
+    install(new HealthModule());
 
     BuildInfo buildInfo = BuildInfo.load(ResteasyBootstrapModule.class.getResourceAsStream("build-info.properties"));
     bind(BuildInfo.class).toInstance(buildInfo);

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/ResteasyBootstrapModule.java
@@ -15,6 +15,7 @@ public class ResteasyBootstrapModule extends AbstractModule {
 
   protected void configure() {
     install(new ResteasyModule());
+    install(new StagemonitorModule());
 
     BuildInfo buildInfo = BuildInfo.load(ResteasyBootstrapModule.class.getResourceAsStream("build-info.properties"));
     bind(BuildInfo.class).toInstance(buildInfo);

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/__name__ContextListener.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/__name__ContextListener.java
@@ -3,7 +3,6 @@
 #set( $symbol_escape = '\' )
 package ${package}.service;
 
-import com.cerner.beadledom.configuration.ConfigurationSource;
 import com.cerner.beadledom.resteasy.ResteasyContextListener;
 import com.google.common.collect.Lists;
 import com.google.inject.Module;

--- a/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/resource/HelloWorldResourceImpl.java
+++ b/archetype/simple-service/src/main/resources/archetype-resources/service/src/main/java/service/resource/HelloWorldResourceImpl.java
@@ -7,7 +7,6 @@ import ${package}.api.HelloWorldResource;
 import ${package}.api.model.HelloWorldDto;
 import com.cerner.beadledom.jaxrs.GenericResponse;
 import com.cerner.beadledom.jaxrs.GenericResponses;
-import javax.ws.rs.core.Response;
 
 public class HelloWorldResourceImpl implements HelloWorldResource {
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,10 +18,6 @@
         </dependency>
         <dependency>
             <groupId>com.cerner.beadledom</groupId>
-            <artifactId>beadledom-health</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.cerner.beadledom</groupId>
             <artifactId>beadledom-jackson</artifactId>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,10 +30,6 @@
         </dependency>
         <dependency>
             <groupId>com.cerner.beadledom</groupId>
-            <artifactId>beadledom-stagemonitor</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.cerner.beadledom</groupId>
             <artifactId>beadledom-swagger</artifactId>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,18 +29,6 @@
             <artifactId>beadledom-jaxrs</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.cerner.beadledom</groupId>
-            <artifactId>beadledom-swagger</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.cerner.beadledom.avro</groupId>
-            <artifactId>beadledom-avro-jackson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.cerner.beadledom.avro</groupId>
-            <artifactId>beadledom-avro-swagger</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/core/src/main/java/com/cerner/beadledom/core/BeadledomModule.java
+++ b/core/src/main/java/com/cerner/beadledom/core/BeadledomModule.java
@@ -11,7 +11,6 @@ import com.cerner.beadledom.jaxrs.exceptionmapping.JsonParseExceptionMapper;
 import com.cerner.beadledom.jaxrs.exceptionmapping.ThrowableExceptionMapper;
 import com.cerner.beadledom.jaxrs.exceptionmapping.WebApplicationExceptionMapper;
 import com.cerner.beadledom.jaxrs.provider.FilteringJacksonJsonProvider;
-import com.cerner.beadledom.stagemonitor.StagemonitorModule;
 import com.cerner.beadledom.swagger.SwaggerModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
@@ -19,9 +18,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
 /**
- * The core Beadledom module that installs and integrates all of the beadledom components.
+ * The core Beadledom module that installs and integrates all of the Beadledom components.
  *
- * <p>This module is only dependent on the jax-rs API. When using beadledom with a jax-rs
+ * <p>This module is only dependent on the jax-rs API. When using Beadledom with a jax-rs
  * implementation, use something like the {@code ResteasyModule} from beadledom-resteasy.
  *
  * <p>Provides:
@@ -43,7 +42,6 @@ public class BeadledomModule extends AbstractModule {
     install(new HealthModule());
     install(new JacksonModule());
     install(new JaxRsModule());
-    install(new StagemonitorModule());
     install(new SwaggerModule());
 
     bind(JsonParseExceptionMapper.class);

--- a/core/src/main/java/com/cerner/beadledom/core/BeadledomModule.java
+++ b/core/src/main/java/com/cerner/beadledom/core/BeadledomModule.java
@@ -1,7 +1,6 @@
 package com.cerner.beadledom.core;
 
 import com.cerner.beadledom.configuration.BeadledomConfigurationModule;
-import com.cerner.beadledom.health.HealthModule;
 import com.cerner.beadledom.jackson.JacksonModule;
 import com.cerner.beadledom.jaxrs.JaxRsModule;
 import com.cerner.beadledom.jaxrs.exceptionmapping.JsonMappingExceptionMapper;
@@ -34,7 +33,6 @@ public class BeadledomModule extends AbstractModule {
   @Override
   protected void configure() {
     install(new BeadledomConfigurationModule());
-    install(new HealthModule());
     install(new JacksonModule());
     install(new JaxRsModule());
 

--- a/core/src/main/java/com/cerner/beadledom/core/BeadledomModule.java
+++ b/core/src/main/java/com/cerner/beadledom/core/BeadledomModule.java
@@ -1,7 +1,5 @@
 package com.cerner.beadledom.core;
 
-import com.cerner.beadledom.avro.AvroJacksonGuiceModule;
-import com.cerner.beadledom.avro.AvroSwaggerGuiceModule;
 import com.cerner.beadledom.configuration.BeadledomConfigurationModule;
 import com.cerner.beadledom.health.HealthModule;
 import com.cerner.beadledom.jackson.JacksonModule;
@@ -11,7 +9,6 @@ import com.cerner.beadledom.jaxrs.exceptionmapping.JsonParseExceptionMapper;
 import com.cerner.beadledom.jaxrs.exceptionmapping.ThrowableExceptionMapper;
 import com.cerner.beadledom.jaxrs.exceptionmapping.WebApplicationExceptionMapper;
 import com.cerner.beadledom.jaxrs.provider.FilteringJacksonJsonProvider;
-import com.cerner.beadledom.swagger.SwaggerModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.inject.AbstractModule;
@@ -36,13 +33,10 @@ import com.google.inject.Provides;
 public class BeadledomModule extends AbstractModule {
   @Override
   protected void configure() {
-    install(new AvroJacksonGuiceModule());
-    install(new AvroSwaggerGuiceModule());
     install(new BeadledomConfigurationModule());
     install(new HealthModule());
     install(new JacksonModule());
     install(new JaxRsModule());
-    install(new SwaggerModule());
 
     bind(JsonParseExceptionMapper.class);
     bind(JsonMappingExceptionMapper.class);

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,5 +11,6 @@ Beadledom
    guides/getting_started
    guides/error_handling
    manual/index
+   releases/index
    guides/troubleshooting
 

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -5,14 +5,10 @@ A Guice module that pulls all of the beadledom components together for consumpti
 
 The following beadledom guice modules are installed.
 
-* `AvroJacksonGuiceModule <avro_jackson>`_
-* `AvroSwaggerGuiceModule <avro_swagger>`_
 * `BeadledomConfigurationModule <configuration>`_
 * `HealthModule <health>`_
 * `JacksonModule <jackson>`_
 * `JaxRsModule <jaxrs>`_
-* `StagemonitorModule <stagemonitor>`_
-* `SwaggerModule <swagger>`_
 
 Download
 --------

--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -6,7 +6,6 @@ A Guice module that pulls all of the beadledom components together for consumpti
 The following beadledom guice modules are installed.
 
 * `BeadledomConfigurationModule <configuration>`_
-* `HealthModule <health>`_
 * `JacksonModule <jackson>`_
 * `JaxRsModule <jaxrs>`_
 

--- a/docs/source/manual/resteasy.rst
+++ b/docs/source/manual/resteasy.rst
@@ -67,14 +67,6 @@ Guice Module:
       bind(ExampleLifecycleHook.class).asEagerSingleton();
     }
 
-    @Provides
-    SwaggerConfig provideSwaggerConfig(ServiceMetadata serviceMetadata) {
-      SwaggerConfig config = new SwaggerConfig();
-      config.setApiVersion(serviceMetadata.getBuildInfo().getVersion());
-      config.setSwaggerVersion(SwaggerSpec.version());
-      return config;
-    }
-
     private static class ExampleLifecycleHook {
       @PostConstruct
       public void postConstruct() {

--- a/docs/source/manual/swagger.rst
+++ b/docs/source/manual/swagger.rst
@@ -15,7 +15,7 @@ Download
       ...
       <dependency>
           <groupId>com.cerner.beadledom</groupId>
-         <artifactId>beadledom-swagger</artifactId>
+          <artifactId>beadledom-swagger</artifactId>
           <version>[Insert latest version]</version>
       </dependency>
       ...
@@ -37,5 +37,13 @@ the ``/api-docs`` endpoint as well as a ``/meta/swagger/ui`` endpoint containing
       ...
       install(new SwaggerModule());
       ...
+    }
+
+    @Provides
+    SwaggerConfig provideSwaggerConfig(ServiceMetadata serviceMetadata) {
+      SwaggerConfig config = new SwaggerConfig();
+      config.setApiVersion(serviceMetadata.getBuildInfo().getVersion());
+      config.setSwaggerVersion(SwaggerSpec.version());
+      return config;
     }
   }

--- a/docs/source/releases/Beadledom30.rst
+++ b/docs/source/releases/Beadledom30.rst
@@ -1,0 +1,38 @@
+.. _3.0:
+
+Beadledom 3.0
+=============
+
+Released <Date>
+
+New Features
+------------
+
+Migrating from Beadledom 2.0
+----------------------------
+Beadledom 3.0 no longer installs StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule,
+and AvroSwaggerGuiceModule modules with BeadledomModule. If the removed functionality is
+desired, install the removed modules in the consuming Guice module. ResteasyModule installs the
+BeadledomModule module, so the removed modules also apply.
+
+.. code-block:: java
+
+  public class MyModule extends AbstractModule {
+
+    protected void configure() {
+      install(new ResteasyModule());
+    }
+  }
+
+  // would become if all removed functionality is desired
+
+  public class MyModule extends AbstractModule {
+
+    protected void configure() {
+      install(new ResteasyModule());
+      install(new StagemonitorModule());
+      install(new SwaggerModule());
+      install(new AvroJacksonGuiceModule());
+      install(new AvroSwaggerGuiceModule());
+    }
+  }

--- a/docs/source/releases/Beadledom30.rst
+++ b/docs/source/releases/Beadledom30.rst
@@ -11,7 +11,7 @@ New Features
 Migrating from Beadledom 2.0
 ----------------------------
 Beadledom 3.0 no longer installs StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule,
-and AvroSwaggerGuiceModule modules with BeadledomModule. If the removed functionality is
+AvroSwaggerGuiceModule, and HealthModule modules with BeadledomModule. If the removed functionality is
 desired, install the removed modules in the consuming Guice module. ResteasyModule installs the
 BeadledomModule module, so the removed modules also apply.
 
@@ -34,5 +34,6 @@ BeadledomModule module, so the removed modules also apply.
       install(new SwaggerModule());
       install(new AvroJacksonGuiceModule());
       install(new AvroSwaggerGuiceModule());
+      install(new HealthModule());
     }
   }

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -1,0 +1,11 @@
+.. _index:
+
+Releases
+########
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+      Beadledom 3.0 <Beadledom30>
+

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -132,6 +132,21 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.cerner.beadledom</groupId>
+            <artifactId>beadledom-swagger</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.cerner.beadledom.avro</groupId>
+            <artifactId>beadledom-avro-jackson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.cerner.beadledom.avro</groupId>
+            <artifactId>beadledom-avro-swagger</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyContextListener.java
+++ b/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyContextListener.java
@@ -1,7 +1,5 @@
 package com.cerner.beadledom.resteasy;
 
-import com.cerner.beadledom.configuration.BeadledomConfigurationModule;
-import com.cerner.beadledom.configuration.ConfigurationSource;
 import com.cerner.beadledom.lifecycle.GuiceLifecycleContainers;
 import com.cerner.beadledom.lifecycle.LifecycleContainer;
 import com.cerner.beadledom.lifecycle.LifecycleInjector;

--- a/resteasy/src/test/java/com/cerner/beadledom/resteasy/fauxservice/FauxModule.java
+++ b/resteasy/src/test/java/com/cerner/beadledom/resteasy/fauxservice/FauxModule.java
@@ -3,6 +3,7 @@ package com.cerner.beadledom.resteasy.fauxservice;
 import com.cerner.beadledom.avro.AvroJacksonGuiceModule;
 import com.cerner.beadledom.avro.AvroSwaggerGuiceModule;
 import com.cerner.beadledom.health.HealthDependency;
+import com.cerner.beadledom.health.HealthModule;
 import com.cerner.beadledom.metadata.BuildInfo;
 import com.cerner.beadledom.metadata.ServiceMetadata;
 import com.cerner.beadledom.resteasy.ResteasyModule;
@@ -30,6 +31,7 @@ public class FauxModule extends AbstractModule {
     install(new SwaggerModule());
     install(new AvroJacksonGuiceModule());
     install(new AvroSwaggerGuiceModule());
+    install(new HealthModule());
 
     bind(HelloDao.class).in(Singleton.class);
     bind(HelloResource.class);

--- a/resteasy/src/test/java/com/cerner/beadledom/resteasy/fauxservice/FauxModule.java
+++ b/resteasy/src/test/java/com/cerner/beadledom/resteasy/fauxservice/FauxModule.java
@@ -1,5 +1,7 @@
 package com.cerner.beadledom.resteasy.fauxservice;
 
+import com.cerner.beadledom.avro.AvroJacksonGuiceModule;
+import com.cerner.beadledom.avro.AvroSwaggerGuiceModule;
 import com.cerner.beadledom.health.HealthDependency;
 import com.cerner.beadledom.metadata.BuildInfo;
 import com.cerner.beadledom.metadata.ServiceMetadata;
@@ -8,6 +10,8 @@ import com.cerner.beadledom.resteasy.fauxservice.dao.HelloDao;
 import com.cerner.beadledom.resteasy.fauxservice.health.ImportantHealthDependency2;
 import com.cerner.beadledom.resteasy.fauxservice.health.ImportantThingHealthDependency;
 import com.cerner.beadledom.resteasy.fauxservice.resource.HelloResource;
+import com.cerner.beadledom.swagger.SwaggerModule;
+
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.multibindings.Multibinder;
@@ -23,6 +27,9 @@ public class FauxModule extends AbstractModule {
   @Override
   protected void configure() {
     install(new ResteasyModule());
+    install(new SwaggerModule());
+    install(new AvroJacksonGuiceModule());
+    install(new AvroSwaggerGuiceModule());
 
     bind(HelloDao.class).in(Singleton.class);
     bind(HelloResource.class);


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

As outlined in #50 by @johnlcox we want the BeadledomModule to only install the minimal set of modules. This PR removes Avro, Swagger, and Stagemonitor from being installed from BeadledomModule.


How was it tested?
----

* Made sure project still built.
* Generated a new project using the archetype and verified the generated code and service worked.


How to test
----

- [ ] `mvn clean install -U`
- Generate project and verify project functions correctly

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
