### PR TITLE
Add environment variables configuration source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 2.7 - 
+
+### Additions
+* Add environment variables configuration source
+
 ## 2.6.1 - 22 September 2017
 
 ### Enhancements

--- a/configuration/src/main/java/com/cerner/beadledom/configuration/EnvironmentConfigurationSource.java
+++ b/configuration/src/main/java/com/cerner/beadledom/configuration/EnvironmentConfigurationSource.java
@@ -6,6 +6,8 @@ import org.apache.commons.configuration2.EnvironmentConfiguration;
 /**
  * An implementation class of {@link ConfigurationSource} for the source of environment variables.
  *
+ * @see <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">Environment Variables</a>
+ *
  * @author Nathan Schile
  * @since 2.7
  */

--- a/configuration/src/main/java/com/cerner/beadledom/configuration/EnvironmentConfigurationSource.java
+++ b/configuration/src/main/java/com/cerner/beadledom/configuration/EnvironmentConfigurationSource.java
@@ -1,0 +1,68 @@
+package com.cerner.beadledom.configuration;
+
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.EnvironmentConfiguration;
+
+/**
+ * An implementation class of {@link ConfigurationSource} for the source of environment variables.
+ *
+ * @author Nathan Schile
+ * @since 2.7
+ */
+public class EnvironmentConfigurationSource extends AbstractConfigurationSource {
+
+  public static final int DEFAULT_PRIORITY = 400;
+  private final int priority;
+  private final Configuration configuration;
+
+  private EnvironmentConfigurationSource(EnvironmentConfiguration configuration, int priority) {
+    if (configuration == null) {
+      throw new NullPointerException("configuration: null");
+    }
+    if (priority < 0) {
+      throw new IllegalArgumentException("priority of a configuration cannot be negative");
+    }
+
+    this.configuration = configuration;
+    this.priority = priority;
+  }
+
+  /**
+   * Creates an instance of {@link EnvironmentConfigurationSource}.
+   */
+  public static EnvironmentConfigurationSource create() {
+    return EnvironmentConfigurationSource.create(DEFAULT_PRIORITY);
+  }
+
+  /**
+   * Creates an instance of {@link EnvironmentConfigurationSource}.
+   *
+   * @param priority priority at which this {@link ConfigurationSource} to be loaded among other
+   *     Configuration sources
+   */
+  public static EnvironmentConfigurationSource create(int priority) {
+    return new EnvironmentConfigurationSource(new EnvironmentConfiguration(), priority);
+  }
+
+  /**
+   * Creates an instance of {@link EnvironmentConfigurationSource}.
+   *
+   * @param configuration the system configuration to delegate to
+   * @param priority priority at which this {@link ConfigurationSource} to be loaded among other
+   *     Configuration sources
+   */
+  public static EnvironmentConfigurationSource create(
+      EnvironmentConfiguration configuration, int priority) {
+    return new EnvironmentConfigurationSource(configuration, priority);
+  }
+
+  @Override
+  public Configuration getConfig() {
+    return configuration;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+}

--- a/configuration/src/main/java/com/cerner/beadledom/configuration/XmlConfigurationSource.java
+++ b/configuration/src/main/java/com/cerner/beadledom/configuration/XmlConfigurationSource.java
@@ -12,7 +12,7 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.io.FileHandler;
 
 /**
- * An implementation class of {@link ConfigurationSource} for the source of type {@link Properties}.
+ * An implementation class of {@link ConfigurationSource} for the source of type {@link XMLConfiguration}.
  *
  * <p>A property whose value is a sequence (ex: list, set) of objects must be placed in its own
  * attribute name. For example
@@ -88,8 +88,7 @@ public final class XmlConfigurationSource extends AbstractConfigurationSource {
 
     FileBasedConfigurationBuilder<FileBasedConfiguration> builder =
         new FileBasedConfigurationBuilder<FileBasedConfiguration>(XMLConfiguration.class)
-            .configure(new Parameters()
-                .xml());
+            .configure(new Parameters().xml());
 
     FileBasedConfiguration fileBasedConfiguration = builder.getConfiguration();
 

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/EnvironmentConfigurationSourceSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/EnvironmentConfigurationSourceSpec.scala
@@ -1,0 +1,37 @@
+package com.cerner.beadledom.configuration
+
+import org.apache.commons.configuration2.{Configuration, EnvironmentConfiguration}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, MustMatchers}
+
+/**
+  * Specs for [[EnvironmentConfigurationSource]].
+  */
+class EnvironmentConfigurationSourceSpec
+    extends FunSpec with BeforeAndAfterAll with MustMatchers {
+
+  describe("EnvironmentConfigurationSource") {
+
+    it("throws NPE when configuration is null") {
+      intercept[NullPointerException] {
+        EnvironmentConfigurationSource.create(null.asInstanceOf[EnvironmentConfiguration], 100)
+      }
+    }
+
+    it("throws IllegalArgumentException if priority is a negative value") {
+      intercept[IllegalArgumentException] {
+        EnvironmentConfigurationSource.create(-1)
+      }
+    }
+
+    it("returns the Configuration") {
+      val config = EnvironmentConfigurationSource.create().getConfig
+      config.isInstanceOf[Configuration] must be(true)
+      config.getProperty("PATH") must be(System.getenv("PATH"))
+    }
+
+    it("returns the priority") {
+      EnvironmentConfigurationSource.create().getPriority must
+          be(EnvironmentConfigurationSource.DEFAULT_PRIORITY)
+    }
+  }
+}

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -80,7 +80,7 @@ and `Defining a custom natural ordering <#defining-a-custom-natural-ordering>`__
 Environment Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Environment variables are a common way to configuration applications in a `Twelve-Factor App
+Environment variables are a common way to configure applications in a `Twelve-Factor App
 <https://12factor.net/config>`__.
 
 To load the environment-based configuration use

--- a/docs/source/manual/configuration.rst
+++ b/docs/source/manual/configuration.rst
@@ -51,7 +51,7 @@ configuration. Each ConfigurationSource is assigned a default priority,
 however the consumer can override the priority at the time of object
 creation. These priorities acts as the natural ordering on the
 ConfigurationSources. The higher priority configuration sources takes
-precendence over the lower priority configuration sources. If a
+precedence over the lower priority configuration sources. If a
 configuration key is found in two different sources, the value from the
 higher priority source will be in the final configuration and the value
 from the lower priority source will not be present in the final
@@ -65,15 +65,29 @@ ConfigurationSourcesModuleBuilder as explained in the `usage <#usage>`__. For mo
 defining a custom configuration sources see `Adding Custom ConfigurationSource <#adding-custom-configurationSource>`__ 
 and `Defining a custom natural ordering <#defining-a-custom-natural-ordering>`__ sections.
 
-+------------------------------------------------------------+--------------------+
-| Configuration type                                         | Default Priority   |
-+============================================================+====================+
-| `Jndi Configuration <#jndi-configuration>`__               | 300                |
-+------------------------------------------------------------+--------------------+
-| `Properties Configuration <#properties-configuration>`__   | 200                |
-+------------------------------------------------------------+--------------------+
-| `XML Configuration <#xml-configuration>`__                 | 100                |
-+------------------------------------------------------------+--------------------+
++--------------------------------------------------------------------------+--------------------+
+| Configuration type                                                       | Default Priority   |
++==========================================================================+====================+
+| `Environment Configuration <#environment-configuration>`__               | 400                |
++--------------------------------------------------------------------------+--------------------+
+| `Jndi Configuration <#jndi-configuration>`__                             | 300                |
++--------------------------------------------------------------------------+--------------------+
+| `Properties Configuration <#properties-configuration>`__                 | 200                |
++--------------------------------------------------------------------------+--------------------+
+| `XML Configuration <#xml-configuration>`__                               | 100                |
++--------------------------------------------------------------------------+--------------------+
+
+Environment Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Environment variables are a common way to configuration applications in a `Twelve-Factor App
+<https://12factor.net/config>`__.
+
+To load the environment-based configuration use
+
+.. code:: java
+
+  EnvironmentConfigurationSource environmentConfigurationSource = EnvironmentConfigurationSource.create());
 
 JNDI Configuration
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

This PR adds a configuration sourced by environment variables. This will be beneficial when deploying a service using Docker.


How was it tested?
----
Created a new project and added

```
install(ConfigurationSourcesModuleBuilder.newBuilder()
        .addSource(EnvironmentConfigurationSource.create())
        .build());
```

This allowed the reading of environment variables through the ImmutableHierarchicalConfiguration


How to test
----

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
