### PR TITLE
Upgrade mockito to 2.10

### DIFF
--- a/avro/jackson/pom.xml
+++ b/avro/jackson/pom.xml
@@ -55,7 +55,7 @@
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/client/beadledom-client-guice/pom.xml
+++ b/client/beadledom-client-guice/pom.xml
@@ -48,7 +48,7 @@
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/client/beadledom-client-jackson/pom.xml
+++ b/client/beadledom-client-jackson/pom.xml
@@ -44,7 +44,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/client/beadledom-client/pom.xml
+++ b/client/beadledom-client/pom.xml
@@ -33,7 +33,7 @@
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/client/beadledom-jaxrs-clientproxy/pom.xml
+++ b/client/beadledom-jaxrs-clientproxy/pom.xml
@@ -28,7 +28,7 @@
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/client/resteasy-client/pom.xml
+++ b/client/resteasy-client/pom.xml
@@ -128,7 +128,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,7 +30,7 @@
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/google_checks_1.8.xml
+++ b/google_checks_1.8.xml
@@ -113,7 +113,7 @@
                      value="Parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="CatchParameterName">
-            <property name="format" value="(^e$)|(^[]a-z][a-z0-9][a-zA-Z0-9]*$)"/>
+            <property name="format" value="(^e$)|(^t$)|(^[]a-z][a-z0-9][a-zA-Z0-9]*$)"/>
             <message key="name.invalidPattern"
                      value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
@@ -201,7 +201,7 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test, GET, POST, PUT, DELETE, HEAD"/>
+            <property name="allowedAnnotations" value="Override, Test, GET, POST, PUT, PATCH, DELETE, HEAD"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
             <property name="suppressLoadErrors" value="true"/>
         </module>

--- a/health/api/pom.xml
+++ b/health/api/pom.xml
@@ -52,7 +52,7 @@
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/health/service/pom.xml
+++ b/health/service/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/DependenciesResourceImplSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/DependenciesResourceImplSpec.scala
@@ -8,7 +8,7 @@ import com.github.mustachejava.DefaultMustacheFactory
 import com.google.inject.{AbstractModule, Guice}
 import java.net.URI
 import javax.ws.rs.core.{UriBuilder, UriInfo}
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/DiagnosticResourceImplSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/DiagnosticResourceImplSpec.scala
@@ -8,7 +8,7 @@ import com.github.mustachejava.DefaultMustacheFactory
 import com.google.inject.{AbstractModule, Guice}
 import java.net.URI
 import javax.ws.rs.core.{UriBuilder, UriInfo}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/HealthResourceImplSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/HealthResourceImplSpec.scala
@@ -8,7 +8,7 @@ import com.github.mustachejava.DefaultMustacheFactory
 import com.google.inject.{AbstractModule, Guice}
 import java.net.URI
 import javax.ws.rs.core.{UriBuilder, UriInfo}
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/jaxrs-genericresponse/pom.xml
+++ b/jaxrs-genericresponse/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalacheck</groupId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterBehaviors.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterBehaviors.scala
@@ -36,7 +36,7 @@ trait CorrelationIdFilterBehaviors extends BeforeAndAfter with ShouldMatchers {
 
       val captor = ArgumentCaptor.forClass(classOf[String])
       Mockito.verify(request)
-          .setProperty(mockito.Matchers.eq(mdcName), captor.capture())
+          .setProperty(mockito.ArgumentMatchers.eq(mdcName), captor.capture())
       MDC.get(mdcName) should be(captor.getValue)
     }
 
@@ -67,8 +67,8 @@ trait CorrelationIdFilterBehaviors extends BeforeAndAfter with ShouldMatchers {
       filter.filter(request, response)
 
       MDC.get(mdcName) should be(null)
-      Mockito.verify(headers).add(mockito.Matchers.eq(headerName),
-        mockito.Matchers.anyString())
+      Mockito.verify(headers).add(mockito.ArgumentMatchers.eq(headerName),
+        mockito.ArgumentMatchers.anyString())
     }
   }
 }

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/FilteringJacksonJsonProviderSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/FilteringJacksonJsonProviderSpec.scala
@@ -48,7 +48,7 @@ class FilteringJacksonJsonProviderSpec
       val json = objectMapper.writeValueAsString(fakeModel)
       val captor = ArgumentCaptor.forClass(classOf[Array[Byte]])
       Mockito.verify(output)
-          .write(captor.capture(), mockito.Matchers.anyInt(), mockito.Matchers.anyInt())
+          .write(captor.capture(), mockito.ArgumentMatchers.anyInt(), mockito.ArgumentMatchers.anyInt())
       json should be === objectMapper.readTree(captor.getValue).toString
     }
 
@@ -73,7 +73,7 @@ class FilteringJacksonJsonProviderSpec
       val json = """{"id":"id1","name":"name1","times":1}"""
       val captor = ArgumentCaptor.forClass(classOf[Array[Byte]])
       Mockito.verify(output)
-          .write(captor.capture(), mockito.Matchers.anyInt(), mockito.Matchers.anyInt())
+          .write(captor.capture(), mockito.ArgumentMatchers.anyInt(), mockito.ArgumentMatchers.anyInt())
       json should be === objectMapper.readTree(captor.getValue).toString
     }
 

--- a/lifecycle-governator/pom.xml
+++ b/lifecycle-governator/pom.xml
@@ -23,7 +23,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -33,7 +33,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleProvisionListenerSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleProvisionListenerSpec.scala
@@ -4,16 +4,17 @@ import com.google.inject.spi.ProvisionListener.ProvisionInvocation
 import com.google.inject.{Binding, Key}
 import javax.annotation.{PostConstruct, PreDestroy}
 import org.hamcrest.Matchers.contains
-import org.mockito.{Matchers, Mockito}
+import org.mockito.Mockito
+import org.mockito.hamcrest.MockitoHamcrest
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.reflect.Manifest
 
 /**
-  * Unit tests for [[LifecycleProvisionListener]].
-  *
-  * @author John Leacox
-  */
+ * Unit tests for [[LifecycleProvisionListener]].
+ *
+ * @author John Leacox
+ */
 class LifecycleProvisionListenerSpec extends FunSpec with MustMatchers with MockitoSugar {
   describe("LifecycleProvisionListener") {
     describe("#onProvision") {
@@ -32,7 +33,7 @@ class LifecycleProvisionListenerSpec extends FunSpec with MustMatchers with Mock
       it("executes PostConstruct methods on the parent class of injectee") {
         val shutdownManager = mock[LifecycleShutdownManager]
         val provisionListener = new LifecycleProvisionListener()
-                LifecycleProvisionListener.init(shutdownManager, provisionListener)
+        LifecycleProvisionListener.init(shutdownManager, provisionListener)
 
         val injectee = new TestPostConstructWithParent
         val provision = createMockProvision(injectee, classOf[TestPostConstructWithParent])
@@ -44,7 +45,7 @@ class LifecycleProvisionListenerSpec extends FunSpec with MustMatchers with Mock
       it("adds PreDestroy methods to the shutdown manager") {
         val shutdownManager = mock[LifecycleShutdownManager]
         val provisionListener = new LifecycleProvisionListener()
-                LifecycleProvisionListener.init(shutdownManager, provisionListener)
+        LifecycleProvisionListener.init(shutdownManager, provisionListener)
 
         val injectee = new TestPreDestroy
         val provision = createMockProvision(injectee, classOf[TestPreDestroy])
@@ -54,7 +55,7 @@ class LifecycleProvisionListenerSpec extends FunSpec with MustMatchers with Mock
           classOf[TestPreDestroy].getDeclaredMethod("shutdown"), classOf[PreDestroy])
 
         Mockito.verify(shutdownManager).addPreDestroyMethods(
-          Matchers.argThat(contains(invokableShutdownMethod))
+          MockitoHamcrest.argThat(contains(invokableShutdownMethod))
               .asInstanceOf[java.util.List[InvokableLifecycleMethod]])
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -459,8 +459,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.10.19</version>
+                <artifactId>mockito-core</artifactId>
+                <version>2.10.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -875,7 +875,7 @@
                 <version>${maven-project-info-reports-plugin-version}</version>
                 <reportSets>
                     <reportSet>
-                        <reports />
+                        <reports/>
                     </reportSet>
                 </reportSets>
                 <configuration>

--- a/resteasy-genericresponse/pom.xml
+++ b/resteasy-genericresponse/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalacheck</groupId>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -126,7 +126,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/stagemonitor/pom.xml
+++ b/stagemonitor/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>

--- a/stagemonitor/src/test/scala/com/cerner/beadledom/stagemonitor/request/LogJsonRequestTraceReporterSpec.scala
+++ b/stagemonitor/src/test/scala/com/cerner/beadledom/stagemonitor/request/LogJsonRequestTraceReporterSpec.scala
@@ -4,7 +4,7 @@ import com.cerner.beadledom.stagemonitor.JsonRequestTraceLoggerPlugin
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.mockito.ArgumentCaptor
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{never, verify, when}
 import org.scalatest._
 import org.scalatest.mock.MockitoSugar

--- a/swagger/pom.xml
+++ b/swagger/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Upgrades mockito from 1.x to 2.x.

How was it tested?
----

* Ran existing tests.
* Ran `mvn dependency:tree | grep mockito` to confirm only 2.x versions were being pulled in.

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
