### PR TITLE
Upgrade modules to Java 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Breaking Changes
 
-* Removes StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, AvroSwaggerGuiceModule, and 
+* Remove StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, AvroSwaggerGuiceModule, and 
 HealthModule modules from being installed by BeadledomModule. If the removed functionality is 
 desired, install the removed modules in the consuming guice module.
+* Bump minimum Java version to 1.8 for all modules.
 
 ## 2.7 - In Development
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,12 +26,6 @@
         <module>beadledom-client-test</module>
     </modules>
 
-    <properties>
-        <java.version>1.6</java.version>
-        <!-- Cannot go past 3.0.12.Final since 3.0.13.Final+ require Java 7 -->
-        <resteasy.client.version>3.0.12.Final</resteasy.client.version>
-    </properties>
-    
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -51,23 +45,18 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>jaxrs-api</artifactId>
-                <version>${resteasy.client.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
-                <version>${resteasy.client.version}</version>
+                <version>${resteasy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-guice</artifactId>
-                <version>${resteasy.client.version}</version>
+                <version>${resteasy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jaxrs</artifactId>
-                <version>${resteasy.client.version}</version>
+                <version>${resteasy.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/client/resteasy-client/pom.xml
+++ b/client/resteasy-client/pom.xml
@@ -50,10 +50,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>jaxrs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
         </dependency>
         <dependency>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -10,10 +10,6 @@
     <artifactId>beadledom-configuration</artifactId>
     <name>Beadledom Configuration</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/guice-dynamicbindings/pom.xml
+++ b/guice-dynamicbindings/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>beadledom-guice-dynamicbindings</artifactId>
     <name>Beadledom Guice DynamicBindings</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.cerner.beadledom</groupId>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>beadledom-guice</artifactId>
     <name>Beadledom Guice</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>beadledom-jackson</artifactId>
     <name>Beadledom Jackson</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/jaxrs-genericresponse/pom.xml
+++ b/jaxrs-genericresponse/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>beadledom-jaxrs-genericresponse</artifactId>
     <name>Beadledom Generic Response - JAX-RS</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>

--- a/lifecycle/pom.xml
+++ b/lifecycle/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>beadledom-lifecycle</artifactId>
     <name>Beadledom Lifecycle</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -412,11 +412,6 @@
             </dependency>
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>jaxrs-api</artifactId>
-                <version>3.0.12.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
                 <version>${resteasy.version}</version>
             </dependency>

--- a/resteasy-genericresponse/pom.xml
+++ b/resteasy-genericresponse/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>beadledom-resteasy-genericresponse</artifactId>
     <name>Beadledom Generic Response - Resteasy</name>
 
-    <properties>
-        <java.version>1.6</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.cerner.beadledom</groupId>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Make Java 1.8 the minimum Java version so we no longer have a mismatch.

How was it tested?
----

Existing unit tests and integration tests.

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
