### PR TITLE
Add back support for GZIP encoding with the Resteasy 3.1 upgrade

### DIFF
--- a/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyModule.java
+++ b/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyModule.java
@@ -4,8 +4,10 @@ import com.cerner.beadledom.core.BeadledomModule;
 import com.cerner.beadledom.resteasy.exceptionmapping.FailureExceptionMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 import org.jboss.resteasy.plugins.guice.ext.RequestScopeModule;
+import org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor;
 
 /**
  * The core guice module for Beadledom on Resteasy.
@@ -34,7 +36,14 @@ public class ResteasyModule extends AbstractModule {
   }
 
   @Provides
+  @Singleton
   GzipContentEncodingFilter provideGzipContentEncodingFilter() {
     return new GzipContentEncodingFilter();
+  }
+
+  @Provides
+  @Singleton
+  GZIPEncodingInterceptor provideGzipEncodingInterceptor() {
+    return new GZIPEncodingInterceptor();
   }
 }


### PR DESCRIPTION
Resteasy 3.1+ no longer supports GZIP encoding by default. This adds back support for GZIP.