### PR TITLE
Add dependency-check plugin

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+  <!-- This CVE is regarding the javascript not the Java implementation -->
   <suppress>
     <notes><![CDATA[
    file name: compiler-0.9.5.jar
@@ -7,6 +8,7 @@
     <gav regex="true">^com\.github\.spullara\.mustache\.java:compiler:.*$</gav>
     <cve>CVE-2015-8862</cve>
   </suppress>
+  <!-- This CVE is regarding xzgrep not the Java implementation -->
   <suppress>
     <notes><![CDATA[
    file name: xz-1.8.jar

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+  <suppress>
+    <notes><![CDATA[
+   file name: compiler-0.9.5.jar
+   ]]></notes>
+    <gav regex="true">^com\.github\.spullara\.mustache\.java:compiler:.*$</gav>
+    <cve>CVE-2015-8862</cve>
+  </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: xz-1.8.jar
+   ]]></notes>
+    <gav regex="true">^org\.tukaani:xz:.*$</gav>
+    <cve>CVE-2015-4035</cve>
+  </suppress>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
   <properties>
     <beadledom.url>http://cerner.github.io/beadledom/${project.version}</beadledom.url>
     <java.version>1.8</java.version>
-    <scala.version>2.11.7</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.4</governator.version>
     <jackson.version>2.9.2</jackson.version>
@@ -451,6 +451,11 @@
         <artifactId>stagemonitor-web</artifactId>
         <version>${stagemonitor.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.tukaani</groupId>
+        <artifactId>xz</artifactId>
+        <version>1.8</version>
+      </dependency>
 
       <!--Test Dependencies-->
       <dependency>
@@ -467,7 +472,25 @@
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
+        <artifactId>scalap</artifactId>
+        <version>${scala.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-compiler</artifactId>
+        <version>${scala.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
+        <version>${scala.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-reflect</artifactId>
         <version>${scala.version}</version>
         <scope>test</scope>
       </dependency>
@@ -644,6 +667,22 @@
             <version>1.9.4</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
+          <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Adds the `dependency-check-plugin` to scan dependencies for OWASP issues. Also updates the dependencies that have fixes and suppresses the ones that are false positives.


How was it tested?
----

Ran `mvn clean install site`


How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Supriya Lal](https://github.com/lal-s)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
