### PR TITLE
Make GenericResponse extend the Closeable interface

### DIFF
--- a/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/GenericResponse.java
+++ b/jaxrs-genericresponse/src/main/java/com/cerner/beadledom/jaxrs/GenericResponse.java
@@ -1,5 +1,6 @@
 package com.cerner.beadledom.jaxrs;
 
+import java.io.Closeable;
 import java.net.URI;
 import java.util.Date;
 import java.util.Locale;
@@ -31,7 +32,7 @@ import javax.ws.rs.core.Response;
  * @since 1.3
  * @see Response
  */
-public interface GenericResponse<T> {
+public interface GenericResponse<T> extends Closeable {
   /**
    * Returns true if {@link #getStatus()} is in the range [200..300), false otherwise.
    */


### PR DESCRIPTION
By extending the Closeable interface the GenericResponse interface will also
automatically extend the AutoClosable interface when used in a runtime
environment running Java 7+. This allows the response to be used with a
try-with-resources statement while still being Java 6 compatible.

How was it tested?
----

Ran the existing tests.


How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
