### PR TITLE
Add New Relic module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 2.8 - TBD
+
+### Additions
+* Add [New Relic](https://newrelic.com/) module.
+
 ## 2.7.2 - 11 April 2018
 
 ### Additions

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,7 +18,7 @@
 [john-leacox]: https://github.com/johnlcox
 [jacob-williams]: https://github.com/brokensandals
 [jonathan-wright]: https://github.com/jonnywri
-[nathan-schile]: https://github.com/shiftyeyes
+[nathan-schile]: https://github.com/nathanschile
 [alec-sears]: https://github.com/alecxvs
 [nimesh-subramanian]: https://github.com/nimeshsubramanian
 [sundeep-paruvu]: https://github.com/sparuvu

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -106,6 +106,11 @@
             </dependency>
             <dependency>
                 <groupId>com.cerner.beadledom</groupId>
+                <artifactId>beadledom-newrelic</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.cerner.beadledom</groupId>
                 <artifactId>beadledom-resteasy</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/source/manual/index.rst
+++ b/docs/source/manual/index.rst
@@ -20,6 +20,7 @@ User Manual
     Beadledom JAX-RS <jaxrs>
     Beadledom JAX-RS - Generic Response <jaxrs_generic_response>
     Beadledom jOOQ <jooq>
+    Beadledom New Relic <newrelic>
     Beadledom Resteasy <resteasy>
     Beadledom Resteasy - Generic Response <resteasy_generic_response>
     Beadledom Stagemonitor <stagemonitor>

--- a/docs/source/manual/newrelic.rst
+++ b/docs/source/manual/newrelic.rst
@@ -1,0 +1,47 @@
+.. _beadledom-newrelic:
+
+beadledom-newrelic
+==================
+
+Beadledom New Relic is a Google Guice extension for `New Relic`_, adding metadata to New Relic transactions.
+
+ 
+Download
+--------
+
+Download using Maven
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: xml
+
+  <dependencies>
+      ...
+      <dependency>
+          <groupId>com.cerner.beadledom</groupId>
+          <artifactId>beadledom-newrelic</artifactId>
+          <version>[Insert latest version]</version>
+      </dependency>
+      ...
+  </dependencies>
+
+Usage
+-----
+
+NewRelicModule_ is used to add a JAXRS request filter that adds the correlation id from the HTTP requests to New Relic transactions.
+
+Install NewRelicModule module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: java
+
+  public class SomeModule extends BaseModule {
+      @Override
+      protected void configure() {
+          ....
+          install(new NewRelicModule());
+          ....
+      }
+  }
+
+.. _New Relic: https://newrelic.com/
+.. _NewRelicModule: https://github.com/cerner/beadledom/blob/master/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicModule.java

--- a/newrelic/pom.xml
+++ b/newrelic/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>beadledom-parent</artifactId>
+    <groupId>com.cerner.beadledom</groupId>
+    <version>2.8-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>beadledom-newrelic</artifactId>
+  <name>Beadledom New Relic</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.newrelic.agent.java</groupId>
+      <artifactId>newrelic-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>jaxrs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.cerner.beadledom</groupId>
+      <artifactId>beadledom-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!--Test Dependencies-->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicApi.java
+++ b/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicApi.java
@@ -1,0 +1,19 @@
+package com.cerner.beadledom.newrelic;
+
+/**
+ * New Relic API. The API mimics the actual New Relic API, however without the static methods.
+ *
+ * @author Nathan Schile
+ * @since 2.8
+ */
+public interface NewRelicApi {
+
+  /**
+   * Add a key/value pair to the current transaction.
+   *
+   * @param key Custom parameter key.
+   * @param value Custom parameter value.
+   */
+  void addCustomParameter(String key, String value);
+
+}

--- a/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicApiImpl.java
+++ b/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicApiImpl.java
@@ -1,0 +1,15 @@
+package com.cerner.beadledom.newrelic;
+
+/**
+ * Default implementation that delegates to the New Relic API.
+ *
+ * @author Nathan Schile
+ * @since 2.8
+ */
+public class NewRelicApiImpl implements NewRelicApi {
+
+  @Override
+  public void addCustomParameter(String key, String value) {
+    com.newrelic.api.agent.NewRelic.addCustomParameter(key, value);
+  }
+}

--- a/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicModule.java
+++ b/newrelic/src/main/java/com/cerner/beadledom/newrelic/NewRelicModule.java
@@ -1,0 +1,44 @@
+package com.cerner.beadledom.newrelic;
+
+import com.cerner.beadledom.jaxrs.provider.CorrelationIdHeader;
+import com.cerner.beadledom.newrelic.jaxrs.NewRelicCorrelationIdFilter;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * A Guice module that provides the New Relic integration.
+ *
+ *
+ * <p>Binds:
+ * <ul>
+ *    <li>{@link NewRelicApi} to {@link NewRelicApiImpl}</li>
+ * </ul>
+ *
+ * <p>Provides:
+ * <ul>
+ *     <li>{@link NewRelicCorrelationIdFilter}</li>
+ * </ul>
+ *
+ * @author Nathan Schile
+ * @since 2.8
+ */
+public class NewRelicModule extends AbstractModule {
+
+  private static final String DEFAULT_HEADER_NAME = "Correlation-Id";
+
+  @Override
+  protected void configure() {
+    bind(NewRelicApi.class).to(NewRelicApiImpl.class).in(Singleton.class);
+  }
+
+  @Provides
+  @Singleton
+  NewRelicCorrelationIdFilter provideNewRelicCorrelationIdFilter(
+      @CorrelationIdHeader @Nullable String correlationIdHeader, NewRelicApi newRelic) {
+    return new NewRelicCorrelationIdFilter(Optional.ofNullable(correlationIdHeader).orElse(DEFAULT_HEADER_NAME), newRelic);
+  }
+
+}

--- a/newrelic/src/main/java/com/cerner/beadledom/newrelic/jaxrs/NewRelicCorrelationIdFilter.java
+++ b/newrelic/src/main/java/com/cerner/beadledom/newrelic/jaxrs/NewRelicCorrelationIdFilter.java
@@ -1,0 +1,47 @@
+package com.cerner.beadledom.newrelic.jaxrs;
+
+import com.cerner.beadledom.newrelic.NewRelicApi;
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * The NewRelicCorrelationIdFilter reads the correlation id header/property from the request, then
+ * adds it to the New Relic transaction as a custom property. The priority of the filter was set to
+ * 3050 to invoke this filter after {@link com.cerner.beadledom.jaxrs.provider.CorrelationIdFilter}
+ *
+ * @author Nathan Schile
+ * @since 2.8
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR + 50)
+public class NewRelicCorrelationIdFilter implements ContainerRequestFilter {
+
+  private final String headerName;
+  private final NewRelicApi newRelic;
+
+  /**
+   * Creates a new {@link NewRelicCorrelationIdFilter} with the provided correlation id header.
+   *
+   * @param headerName the correlation id header name to be used in request headers.
+   * @param newRelic the New Relic API
+   */
+  public NewRelicCorrelationIdFilter(String headerName, NewRelicApi newRelic) {
+    this.headerName = headerName;
+    this.newRelic = newRelic;
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    String correlationId = requestContext.getHeaderString(headerName);
+    if (correlationId == null) {
+      correlationId = (String) requestContext.getProperty(headerName);
+    }
+
+    if (correlationId != null) {
+      newRelic.addCustomParameter(headerName, correlationId);
+    }
+  }
+}

--- a/newrelic/src/test/scala/com/cerner/beadledom/newrelic/jaxrs/NewRelicCorrelationIdFilterSpec.scala
+++ b/newrelic/src/test/scala/com/cerner/beadledom/newrelic/jaxrs/NewRelicCorrelationIdFilterSpec.scala
@@ -1,0 +1,49 @@
+package com.cerner.beadledom.newrelic.jaxrs
+
+import com.cerner.beadledom.newrelic.NewRelicApi
+import javax.ws.rs.container.ContainerRequestContext
+import org.mockito.Mockito.{reset, when, verify, verifyZeroInteractions}
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+
+class NewRelicCorrelationIdFilterSpec
+  extends FunSpec with BeforeAndAfter with MustMatchers with MockitoSugar {
+
+  val headerName = "Correlation-Id"
+  val id = java.util.UUID.randomUUID.toString
+  val request: ContainerRequestContext = mock[ContainerRequestContext]
+  val newRelic = mock[NewRelicApi]
+  var filter: NewRelicCorrelationIdFilter = _
+
+  before {
+    reset(newRelic, request)
+  }
+
+  describe("filter") {
+    describe("when correlation id header is present") {
+      it("adds the custom parameter on New Relic") {
+        when(request.getHeaderString(headerName)).thenReturn(id, Nil: _*)
+        filter = new NewRelicCorrelationIdFilter(headerName, newRelic)
+        filter.filter(request)
+        verify(newRelic).addCustomParameter(headerName, id)
+      }
+    }
+
+    describe("when correlation id request property is present") {
+      it("adds the custom parameter on New Relic") {
+        when(request.getProperty(headerName)).thenReturn(id, Nil: _*)
+        filter = new NewRelicCorrelationIdFilter(headerName, newRelic)
+        filter.filter(request)
+        verify(newRelic).addCustomParameter(headerName, id)
+      }
+    }
+
+    describe("when correlation id request property is not present and header is not present") {
+      it("does not add the custom parameter on New Relic") {
+        filter = new NewRelicCorrelationIdFilter(headerName, newRelic)
+        filter.filter(request)
+        verifyZeroInteractions(newRelic)
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <module>json-common</module>
         <module>lifecycle</module>
         <module>lifecycle-governator</module>
+        <module>newrelic</module>
         <module>resteasy</module>
         <module>resteasy-genericresponse</module>
         <module>stagemonitor</module>
@@ -193,6 +194,11 @@
             </dependency>
             <dependency>
                 <groupId>com.cerner.beadledom</groupId>
+                <artifactId>beadledom-newrelic</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.cerner.beadledom</groupId>
                 <artifactId>beadledom-resteasy-genericresponse</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -292,6 +298,11 @@
                 <groupId>com.netflix.governator</groupId>
                 <artifactId>governator-core</artifactId>
                 <version>${governator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.newrelic.agent.java</groupId>
+                <artifactId>newrelic-api</artifactId>
+                <version>4.0.0</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe.play</groupId>


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Adds a New Relic module. This was desired in order to to add the HTTP request correlation ID to New Relic transactions.


How was it tested?
----

* Unit tested
* Added the new module to an existing beadledom project. Verified the correlation id on the HTTP request was present in the New Relic transaction.

<img width="594" alt="swagger" src="https://user-images.githubusercontent.com/168653/39265108-04fb091a-488c-11e8-87f5-c8eb57298c82.png">

<img width="771" alt="newrelic" src="https://user-images.githubusercontent.com/168653/39265107-04eeadfa-488c-11e8-8fe6-84d93c391031.png">


How to test
----

- [ ] `mvn clean install -U`

Reviewers
----

- [ ] [John Leacox](https://github.com/johnlcox)
- [ ] [Sundeep Paruvu](https://github.com/sparuvu)
- [ ] [Nimesh Subramanian](https://github.com/nimeshsubramanian)
- [ ] [Brian van de Boogaard](https://github.com/b-boogaard)
