### PR TITLE
Change the HttpClient  to only retry on 503 response codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 HealthModule modules from being installed by BeadledomModule. If the removed functionality is 
 desired, install the removed modules in the consuming guice module.
 * Bump minimum Java version to 1.8 for all modules.
+* Change the HttpClient `ServiceUnavailableRetryStrategy` to only retry on 503 response codes.
 
 ### Enhancements
 * Support building with JDK 9/10+

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategy.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategy.java
@@ -1,6 +1,7 @@
 package com.cerner.beadledom.client.resteasy.http;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.ServiceUnavailableRetryStrategy;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.protocol.HttpContext;
@@ -31,8 +32,7 @@ public class DefaultServiceUnavailableRetryStrategy
   @Override
   public boolean retryRequest(
       HttpResponse httpResponse, int executionCount, HttpContext httpContext) {
-    int status = httpResponse.getStatusLine().getStatusCode();
-    if (executionCount < 3 && status >= 500 && status < 600) {
+    if (executionCount < 3 && isServiceUnavailableResponse(httpResponse)) {
       HttpClientContext context = HttpClientContext.adapt(httpContext);
       logger.info(
           "Retry " + executionCount + " for request for: "
@@ -40,6 +40,10 @@ public class DefaultServiceUnavailableRetryStrategy
       return true;
     }
     return false;
+  }
+
+  private boolean isServiceUnavailableResponse(HttpResponse response) {
+    return response.getStatusLine().getStatusCode() == HttpStatus.SC_SERVICE_UNAVAILABLE;
   }
 
   @Override

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
@@ -1,6 +1,4 @@
-package com.cerner.beadledom.client.common.http
-
-import com.cerner.beadledom.client.resteasy.http.DefaultServiceUnavailableRetryStrategy
+package com.cerner.beadledom.client.resteasy.http
 
 import org.apache.http.client.ServiceUnavailableRetryStrategy
 import org.apache.http.client.protocol.HttpClientContext
@@ -26,19 +24,19 @@ class DefaultServiceUnavailableRetryStrategySpec extends FunSpec with Matchers w
 
     describe("#retryRequest") {
       describe("with status code 500 and executionCount 0") {
-        it should behave like retryableRequest(retryStrategy, 500, 0)
+        it should behave like nonRetryableRequest(retryStrategy, 500, 0)
       }
 
       describe("with status code 500 and executionCount 1") {
-        it should behave like retryableRequest(retryStrategy, 500, 1)
+        it should behave like nonRetryableRequest(retryStrategy, 500, 1)
       }
 
       describe("with status code 500 and executionCount 2") {
-        it should behave like retryableRequest(retryStrategy, 500, 2)
+        it should behave like nonRetryableRequest(retryStrategy, 500, 2)
       }
 
       describe("with status code 599 and executionCount 0") {
-        it should behave like retryableRequest(retryStrategy, 599, 0)
+        it should behave like nonRetryableRequest(retryStrategy, 599, 0)
       }
 
       describe("with status code 503 and executionCount 1") {
@@ -68,9 +66,6 @@ trait RetryRequestBehaviors extends Matchers with MockitoSugar {
   this: FunSpec =>
 
   def retryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int, executionCount: Int): Unit = {
-    require((500 until 600).contains(statusCode))
-    require(executionCount < 3)
-
     it(s"returns true") {
       val response = mockResponse(statusCode)
       val context = mockContext()
@@ -80,8 +75,6 @@ trait RetryRequestBehaviors extends Matchers with MockitoSugar {
   }
 
   def nonRetryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int, executionCount: Int): Unit = {
-    require(!(500 until 600).contains(statusCode) || !(executionCount < 3))
-
     it(s"returns false") {
       val response = mockResponse(statusCode)
       val context = mockContext()

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
@@ -8,9 +8,10 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 
 /**
-  * @author John Leacox
-  */
-class DefaultServiceUnavailableRetryStrategySpec extends FunSpec with Matchers with MockitoSugar with RetryRequestBehaviors {
+ * @author John Leacox
+ */
+class DefaultServiceUnavailableRetryStrategySpec
+    extends FunSpec with Matchers with MockitoSugar with RetryRequestBehaviors {
   describe("DefaultServiceUnavailableRetryStrategySpec") {
     describe("#getRetryInterval") {
       it("returns the retry interval given to the constructor") {
@@ -39,8 +40,20 @@ class DefaultServiceUnavailableRetryStrategySpec extends FunSpec with Matchers w
         it should behave like nonRetryableRequest(retryStrategy, 599, 0)
       }
 
+      describe("with status code 503 and executionCount 0") {
+        it should behave like retryableRequest(retryStrategy, 503, 0)
+      }
+
       describe("with status code 503 and executionCount 1") {
         it should behave like retryableRequest(retryStrategy, 503, 1)
+      }
+
+      describe("with status code 503 and executionCount 2") {
+        it should behave like retryableRequest(retryStrategy, 503, 2)
+      }
+
+      describe("with status code 503 and executionCount 3") {
+        it should behave like nonRetryableRequest(retryStrategy, 503, 3)
       }
 
       describe("with status code 500 and executionCount 3") {
@@ -65,7 +78,8 @@ class DefaultServiceUnavailableRetryStrategySpec extends FunSpec with Matchers w
 trait RetryRequestBehaviors extends Matchers with MockitoSugar {
   this: FunSpec =>
 
-  def retryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int, executionCount: Int): Unit = {
+  def retryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int,
+      executionCount: Int): Unit = {
     it(s"returns true") {
       val response = mockResponse(statusCode)
       val context = mockContext()
@@ -74,7 +88,8 @@ trait RetryRequestBehaviors extends Matchers with MockitoSugar {
     }
   }
 
-  def nonRetryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int, executionCount: Int): Unit = {
+  def nonRetryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int,
+      executionCount: Int): Unit = {
     it(s"returns false") {
       val response = mockResponse(statusCode)
       val context = mockContext()

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapterSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapterSpec.scala
@@ -1,9 +1,6 @@
-package com.cerner.beadledom.client.common.http
-
-import com.cerner.beadledom.client.resteasy.http.X509HostnameVerifierAdapter
+package com.cerner.beadledom.client.resteasy.http
 
 import java.security.cert.X509Certificate
-
 import javax.net.ssl.{HostnameVerifier, SSLException, SSLSession, SSLSocket}
 import org.apache.http.conn.ssl.X509HostnameVerifier
 import org.mockito.Mockito
@@ -11,8 +8,8 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 
 /**
-  * @author John Leacox
-  */
+ * @author John Leacox
+ */
 class X509HostnameVerifierAdapterSpec
     extends FunSpec with Matchers with BeforeAndAfter with MockitoSugar {
   describe("X509HostnameVerifierAdapter") {
@@ -45,7 +42,6 @@ class X509HostnameVerifierAdapterSpec
 
         val verifier = mock[HostnameVerifier]
         Mockito.when(verifier.verify(host, sslSession)).thenReturn(false)
-
 
         intercept[SSLException] {
           X509HostnameVerifierAdapter.adapt(verifier).verify(host, sslSocket)


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Fixes #44.

Change client retries to only retry 503 status codes.

How was it tested?
----

Ran existing unit and integration tests.

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`
