### PR TITLE
Jaxrs upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 HealthModule modules from being installed by BeadledomModule. If the removed functionality is 
 desired, install the removed modules in the consuming guice module.
 * Bump minimum Java version to 1.8 for all modules.
+* Upgrade to JAX-RS 2.1 with Resteasy 3.6.x
 * Change the HttpClient `ServiceUnavailableRetryStrategy` to only retry on 503 response codes.
 
 ### Enhancements

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
@@ -144,12 +144,9 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
    * <p>If a {@link ClientHttpEngine} is specified via {@link #setHttpEngine(ClientHttpEngine)},
    * then this property will be ignored.
    *
-   * <p>Deprecated: Use {@link #readTimeout(long, TimeUnit)} instead.
-   *
    * @return this builder
    */
   @Override
-  @Deprecated
   public BeadledomResteasyClientBuilder setSocketTimeout(int socketTimeout, TimeUnit timeUnit) {
     long millis = timeUnit.toMillis(socketTimeout);
     if (millis > Integer.MAX_VALUE || millis < 0) {
@@ -167,12 +164,9 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
    * <p>If a {@link ClientHttpEngine} is specified via {@link #setHttpEngine(ClientHttpEngine)},
    * then this property will be ignored.
    *
-   * <p>Deprecated: Use {@link #connectTimeout(long, TimeUnit)} instead.
-   *
    * @return this builder
    */
   @Override
-  @Deprecated
   public BeadledomResteasyClientBuilder setConnectionTimeout(
       int connectionTimeout, TimeUnit timeUnit) {
     long millis = timeUnit.toMillis(connectionTimeout);
@@ -322,7 +316,6 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
   }
 
   private ClientHttpEngine initDefaultHttpEngine(BeadledomClientConfiguration clientConfig) {
-
     SocketConfig socketConfig = SocketConfig.custom()
         .setSoTimeout(clientConfig.socketTimeoutMillis())
         .build();

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
@@ -9,6 +9,8 @@ import com.cerner.beadledom.client.resteasy.http.DefaultServiceUnavailableRetryS
 import com.cerner.beadledom.client.resteasy.http.X509HostnameVerifierAdapter;
 import java.security.KeyStore;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -248,6 +250,32 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
   @Override
   public BeadledomResteasyClientBuilder hostnameVerifier(HostnameVerifier verifier) {
     this.clientConfigBuilder.verifier(verifier);
+    return this;
+  }
+
+  @Override
+  public ClientBuilder executorService(ExecutorService executorService) {
+    resteasyClientBuilder.executorService(executorService);
+    return this;
+  }
+
+  @Override
+  public ClientBuilder scheduledExecutorService(ScheduledExecutorService scheduledExecutorService) {
+    resteasyClientBuilder.scheduledExecutorService(scheduledExecutorService);
+    return this;
+  }
+
+  // TODO: How does this map to the existing socket/connect timeout settings?
+  @Override
+  public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+    resteasyClientBuilder.connectTimeout(timeout, unit);
+    return this;
+  }
+
+  // TODO: How does this map to the existing socket/connect timeout settings?
+  @Override
+  public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
+    resteasyClientBuilder.readTimeout(timeout, unit);
     return this;
   }
 

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
@@ -144,19 +144,20 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
    * <p>If a {@link ClientHttpEngine} is specified via {@link #setHttpEngine(ClientHttpEngine)},
    * then this property will be ignored.
    *
+   * <p>Deprecated: Use {@link #readTimeout(long, TimeUnit)} instead.
+   *
    * @return this builder
    */
   @Override
-  public BeadledomResteasyClientBuilder setSocketTimeout(
-      int socketTimeout, TimeUnit timeUnit) {
+  @Deprecated
+  public BeadledomResteasyClientBuilder setSocketTimeout(int socketTimeout, TimeUnit timeUnit) {
     long millis = timeUnit.toMillis(socketTimeout);
     if (millis > Integer.MAX_VALUE || millis < 0) {
       throw new IllegalArgumentException(
-          "Socket timeout must be smaller than Integer.MAX_VALUE when converted to milliseconds");
+          "Socket timeout must be smaller than Integer.MAX_VALUE when converted to milliseconds"
+      );
     }
-
-    this.clientConfigBuilder.socketTimeoutMillis((int) millis);
-    return this;
+    return readTimeout((int) millis, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -166,9 +167,12 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
    * <p>If a {@link ClientHttpEngine} is specified via {@link #setHttpEngine(ClientHttpEngine)},
    * then this property will be ignored.
    *
+   * <p>Deprecated: Use {@link #connectTimeout(long, TimeUnit)} instead.
+   *
    * @return this builder
    */
   @Override
+  @Deprecated
   public BeadledomResteasyClientBuilder setConnectionTimeout(
       int connectionTimeout, TimeUnit timeUnit) {
     long millis = timeUnit.toMillis(connectionTimeout);
@@ -177,8 +181,7 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
           "Connection timeout must be smaller than Integer.MAX_VALUE when converted to milliseconds"
       );
     }
-    this.clientConfigBuilder.connectionTimeoutMillis((int) millis);
-    return this;
+    return connectTimeout((int) millis, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -265,17 +268,28 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
     return this;
   }
 
-  // TODO: How does this map to the existing socket/connect timeout settings?
   @Override
-  public ClientBuilder connectTimeout(long timeout, TimeUnit unit) {
-    resteasyClientBuilder.connectTimeout(timeout, unit);
+  public BeadledomResteasyClientBuilder connectTimeout(long timeout, TimeUnit unit) {
+    long millis = unit.toMillis(timeout);
+    if (millis > Integer.MAX_VALUE || millis < 0) {
+      throw new IllegalArgumentException(
+          "Connect timeout must be smaller than Integer.MAX_VALUE when converted to milliseconds"
+      );
+    }
+
+    this.clientConfigBuilder.connectionTimeoutMillis((int) millis);
     return this;
   }
 
-  // TODO: How does this map to the existing socket/connect timeout settings?
   @Override
-  public ClientBuilder readTimeout(long timeout, TimeUnit unit) {
-    resteasyClientBuilder.readTimeout(timeout, unit);
+  public BeadledomResteasyClientBuilder readTimeout(long timeout, TimeUnit unit) {
+    long millis = unit.toMillis(timeout);
+    if (millis > Integer.MAX_VALUE || millis < 0) {
+      throw new IllegalArgumentException(
+          "Read timeout must be smaller than Integer.MAX_VALUE when converted to milliseconds");
+    }
+
+    this.clientConfigBuilder.socketTimeoutMillis((int) millis);
     return this;
   }
 
@@ -308,6 +322,7 @@ public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
   }
 
   private ClientHttpEngine initDefaultHttpEngine(BeadledomClientConfiguration clientConfig) {
+
     SocketConfig socketConfig = SocketConfig.custom()
         .setSoTimeout(clientConfig.socketTimeoutMillis())
         .build();

--- a/docs/source/releases/Beadledom30.rst
+++ b/docs/source/releases/Beadledom30.rst
@@ -37,3 +37,8 @@ BeadledomModule module, so the removed modules also apply.
       install(new HealthModule());
     }
   }
+
+JAX-RS 2.1 Upgrade
+~~~~~~~~~~~~~~~~~~
+Beadledom 3.0 now uses JAX-RS 2.1 and Resteasy 3.6.x. Change your dependencies on javax.ws.rs-api
+to 2.1 and Resteasy to 3.6.0.Final or the latest 3.6.x version.

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.4</governator.version>
     <jackson.version>2.9.6</jackson.version>
-    <resteasy.version>3.1.4.Final</resteasy.version>
+    <resteasy.version>3.6.0.Final</resteasy.version>
     <spotbugs.version>3.1.1</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
     <swagger-core.version>1.3.12</swagger-core.version>
@@ -360,7 +360,7 @@
       <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>

--- a/resteasy/src/main/java/com/cerner/beadledom/resteasy/GzipContentEncodingFilter.java
+++ b/resteasy/src/main/java/com/cerner/beadledom/resteasy/GzipContentEncodingFilter.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Sets;
 import javax.annotation.Priority;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.ext.Provider;
-import org.jboss.resteasy.plugins.interceptors.ServerContentEncodingAnnotationFilter;
+import org.jboss.resteasy.plugins.interceptors.encoding.ServerContentEncodingAnnotationFilter;
 
 /**
  * A Jax-Rs server filter for setting the gzip content-encoding header if the gzip accept-encoding

--- a/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyModule.java
+++ b/resteasy/src/main/java/com/cerner/beadledom/resteasy/ResteasyModule.java
@@ -7,7 +7,7 @@ import com.google.inject.Provides;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 import org.jboss.resteasy.plugins.guice.ext.RequestScopeModule;
-import org.jboss.resteasy.plugins.interceptors.GZIPEncodingInterceptor;
+import org.jboss.resteasy.plugins.interceptors.encoding.GZIPEncodingInterceptor;
 
 /**
  * The core guice module for Beadledom on Resteasy.


### PR DESCRIPTION
What was changed? Why is this necessary?
----------------------------------------

Upgrades to JAX-RS 2.1 and Resteasy 3.6.x


How was it tested?
----

Existing tests and tried it with an existing beadledom service.

How to test
----

*This is bare minimum acceptable testing*

- [ ] `mvn clean install -U`
