### PR TITLE
Handle jax-rs responses that do not contain a entity (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Beadledom Changelog
 
+## 3.1 - TBD
+
+### Breaking Changes
+
+### Enhancements
+
+### Defects Corrected
+* Fixed beadledom client deserialization to GenericResponse when the JAX-RS response has no entity.
+
 ## 3.0 - 3 August 2018
 
 ### Breaking Changes

--- a/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericClientProxy.java
+++ b/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericClientProxy.java
@@ -52,7 +52,7 @@ class GenericClientProxy implements InvocationHandler {
   private Object buildGenericResponse(Method method, Response response) {
     int code = response.getStatus();
     Object entity = null;
-    if (!(code < 200 || code >= 300)) {
+    if (!(code < 200 || code >= 300) && response.hasEntity()) {
       ParameterizedType genericReturnType = (ParameterizedType) method.getGenericReturnType();
       Type bodyType = genericReturnType.getActualTypeArguments()[0];
 

--- a/client/beadledom-jaxrs-clientproxy/src/test/java/com/cerner/beadledom/client/proxy/GenericTestingResource.java
+++ b/client/beadledom-jaxrs-clientproxy/src/test/java/com/cerner/beadledom/client/proxy/GenericTestingResource.java
@@ -14,5 +14,7 @@ public interface GenericTestingResource {
 
   GenericResponse<String> getGenericWithParameter(String input);
 
+  GenericResponse getGenericWithNoType();
+
   Response getStandard();
 }

--- a/client/beadledom-jaxrs-clientproxy/src/test/java/com/cerner/beadledom/client/proxy/StandardTestingResource.java
+++ b/client/beadledom-jaxrs-clientproxy/src/test/java/com/cerner/beadledom/client/proxy/StandardTestingResource.java
@@ -10,5 +10,7 @@ import javax.ws.rs.core.Response;
 public interface StandardTestingResource {
   Response getGeneric();
 
+  Response getGenericWithNoType();
+
   Response getStandard();
 }

--- a/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericClientProxySpec.scala
+++ b/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericClientProxySpec.scala
@@ -18,6 +18,7 @@ class GenericClientProxySpec extends FunSpec with MustMatchers with MockitoSugar
         val mockResponse = mock[Response]
         when(mockResponse.readEntity(new GenericType(classOf[String]))).thenReturn("Hello World")
         when(mockResponse.getStatus).thenReturn(200)
+        when(mockResponse.hasEntity).thenReturn(true)
         val underlyingProxy = mock[StandardTestingResource]
         when(underlyingProxy.getGeneric).thenReturn(mockResponse)
 
@@ -51,6 +52,27 @@ class GenericClientProxySpec extends FunSpec with MustMatchers with MockitoSugar
 
         response mustBe a [Response]
         response.asInstanceOf[Response].readEntity(classOf[String]) mustBe "Hello World"
+      }
+
+      it("transform the underlying response with no entity into a GenericResponse") {
+        val mockResponse = mock[Response]
+        when(mockResponse.hasEntity).thenReturn(false)
+        when(mockResponse.getStatus).thenReturn(204)
+        val underlyingProxy = mock[StandardTestingResource]
+        when(underlyingProxy.getGenericWithNoType).thenReturn(mockResponse)
+
+        val proxy = mock[GenericTestingResource]
+
+        val clientProxy = new GenericClientProxy(underlyingProxy)
+
+        val method = classOf[GenericTestingResource].getMethod("getGenericWithNoType")
+        val args: Array[AnyRef] = Array[AnyRef]()
+        val response = clientProxy.invoke(proxy, method, args)
+
+        response mustBe a [GenericResponse[_]]
+        val genericResponse = response.asInstanceOf[GenericResponse[_]]
+        genericResponse.body() mustBe null.asInstanceOf[Void]
+        genericResponse.getStatus mustBe 204
       }
     }
   }


### PR DESCRIPTION
### What was changed? Why is this necessary?

Fixes #109 by handling jax-rs respones that do not have a entity.


### How was it tested?

Unit tested


### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
