### PR TITLE
Prepare of 3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Beadledom Changelog
 
-## 3.1 - TBD
+## 3.1 - 12 September 2018
 
 ### Additions
 * Add offset based pagination with beadledom-pagination.
 
-### Breaking Changes
-
 ### Enhancements
-
+* Supports offset based pagination.
 
 ### Defects Corrected
 * Fixed beadledom client deserialization to GenericResponse when the JAX-RS response has no entity.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,13 @@ Note: Releasing the project requires an initial set up. The [Preparing for the R
 
 ## Preparing for the Release
 
+### Sonatype setup
+
 * A valid Sonatype user account is required to release this project. To create an account sign up with [Sonatype](https://issues.sonatype.org/secure/Signup!default.jspa).
+* Once you have the Sonatype user account, you need to comment on this [JIRA](https://issues.sonatype.org/browse/OSSRH-27635) to get yourself added to the Beadledom project group.
+
+### One Time Shared Travis setup
+* These steps need to be performed only if need to do it if we were to revoke secrets in use by travis and create a new one. Since this is shared, only one of the maintainers need to do it. 
 * Execute the following commands in your terminal to prepare travis-ci
 
     ```


### PR DESCRIPTION
### What was changed? Why is this necessary?
* 3.1 release prepare
* Update release docs.



### How to test

- [ ] `./mvnw clean install -U`
