### PR TITLE
Move OffsetPaginatedListDto Client interface to an externally usable package (#114)

### DIFF
--- a/client/beadledom-client-example/example-api/pom.xml
+++ b/client/beadledom-client-example/example-api/pom.xml
@@ -37,5 +37,9 @@
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.cerner.beadledom</groupId>
+      <artifactId>beadledom-client</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/client/beadledom-client-example/example-api/src/main/java/com/cerner/beadledom/client/example/model/JsonOneOffsetPaginatedListDto.java
+++ b/client/beadledom-client-example/example-api/src/main/java/com/cerner/beadledom/client/example/model/JsonOneOffsetPaginatedListDto.java
@@ -1,6 +1,6 @@
 package com.cerner.beadledom.client.example.model;
 
-import com.cerner.beadledom.pagination.models.OffsetPaginatedListDto;
+import com.cerner.beadledom.client.OffsetPaginatedListDto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/client/beadledom-client-example/example-api/src/main/java/com/cerner/beadledom/client/example/model/JsonOneOffsetPaginatedListDto.java
+++ b/client/beadledom-client-example/example-api/src/main/java/com/cerner/beadledom/client/example/model/JsonOneOffsetPaginatedListDto.java
@@ -1,5 +1,6 @@
 package com.cerner.beadledom.client.example.model;
 
+import com.cerner.beadledom.pagination.models.OffsetPaginatedListDto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/client/beadledom-client/pom.xml
+++ b/client/beadledom-client/pom.xml
@@ -13,6 +13,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
     </dependency>
@@ -38,6 +42,10 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.cerner.beadledom</groupId>
+      <artifactId>beadledom-pagination</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/OffsetPaginatedListDto.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/OffsetPaginatedListDto.java
@@ -1,4 +1,4 @@
-package com.cerner.beadledom.client.example.model;
+package com.cerner.beadledom.client;
 
 import com.cerner.beadledom.pagination.OffsetPaginatedList;
 


### PR DESCRIPTION
### What was changed? Why is this necessary?

> These are the changes to go along with issue #114 to move the paginated list interface to a externally usable location

### How was it tested?

> I did a `mvn clean install -U`


### How to test

> This is bare minimum acceptable testing

- [x] `./mvnw clean install -U`
