### PR TITLE
Added pmd plugin to parent pom. Resolves #78

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
     <scala-maven-plugin.version>3.4.1</scala-maven-plugin.version>
     <spotbugs.plugin.version>3.1.5</spotbugs.plugin.version>
+    <pmd.version>6.8.0</pmd.version>
+    <pmd.plugin.version>3.10.0</pmd.plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -751,6 +753,49 @@
           <argLine>-Xms256m -Xmx512m</argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <targetJdk>${java.version}</targetJdk>
+          <!-- TODO: Flip this to true once violations are evaluated or fixed -->
+          <failOnViolation>false</failOnViolation>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-core</artifactId>
+            <version>${pmd.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-java</artifactId>
+            <version>${pmd.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>pmd-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <printFailingErrors>true</printFailingErrors>
+            </configuration>
+          </execution>
+          <execution>
+            <id>cpd-check</id>
+            <goals>
+              <goal>cpd-check</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <printFailingErrors>true</printFailingErrors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -877,6 +922,11 @@
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>${pmd.plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
### What was changed? Why is this necessary?

Added the `maven-pmd-plugin` to the parent pom with default rules per request in issue #78 

*Note* that this is set to _not_ fail the build at this time. 


### How was it tested?

Simply ran `./mvnw clean install -U` locally.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U` 
