### PR TITLE
Swagger2 - Add empty multibinder for ModelConverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@
 ### Defects Corrected
 * Fix isHealthy field being included in the health dependency list JSON.
 
-### Defects Corrected
-* Fix isHealthy field being included in the health dependency list JSON.
-
 ## 3.1 - 12 September 2018
 
 ### Additions

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,4 +16,12 @@
     <gav regex="true">^org\.tukaani:xz:.*$</gav>
     <cve>CVE-2015-4035</cve>
   </suppress>
+  <!-- Vulnerability fix for guava is not released yet so we need to suppress it for the time being -->
+  <suppress>
+    <notes><![CDATA[
+   file name: auto-value-1.6.2.jar/META-INF/maven/com.google.guava/guava/pom.xml
+   ]]></notes>
+    <gav regex="true">^com\.google\.guava:guava:.*$</gav>
+    <cpe>cpe:/a:google:guava</cpe>
+  </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -21,7 +21,7 @@
     <notes><![CDATA[
    file name: auto-value-1.6.2.jar/META-INF/maven/com.google.guava/guava/pom.xml
    ]]></notes>
-    <gav regex="true">^com\.google\.guava:guava:.*$</gav>
+    <filePath regex="true">.*auto-value-1.6.2\.jar.*$</filePath>
     <cpe>cpe:/a:google:guava</cpe>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,7 +16,7 @@
     <gav regex="true">^org\.tukaani:xz:.*$</gav>
     <cve>CVE-2015-4035</cve>
   </suppress>
-  <!-- Vulnerability fix for guava is not released yet so we need to suppress it for the time being -->
+  <!-- Vulnerability fix for auto-value is not released yet so we need to suppress it for the time being -->
   <suppress>
     <notes><![CDATA[
    file name: auto-value-1.6.2.jar/META-INF/maven/com.google.guava/guava/pom.xml

--- a/swagger1/src/main/java/com/cerner/beadledom/swagger/SwaggerModule.java
+++ b/swagger1/src/main/java/com/cerner/beadledom/swagger/SwaggerModule.java
@@ -2,7 +2,6 @@ package com.cerner.beadledom.swagger;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import com.google.inject.multibindings.MultibindingsScanner;
 import com.wordnik.swagger.config.ConfigFactory;
 import com.wordnik.swagger.config.ScannerFactory;
 import com.wordnik.swagger.config.SwaggerConfig;
@@ -62,11 +61,6 @@ import javax.inject.Inject;
  *     <li>{@link com.wordnik.swagger.jaxrs.JaxrsApiReader}</li>
  *     <li>{@link com.wordnik.swagger.jaxrs.config.JaxrsScanner}</li>
  * </ul>
- *
- * <p>Installs:
- * <ul>
- *   <li> {@link MultibindingsScanner} </li>
- * </ul>
  */
 public class SwaggerModule extends AbstractModule {
   @Override
@@ -74,8 +68,7 @@ public class SwaggerModule extends AbstractModule {
     requireBinding(SwaggerConfig.class);
 
     // Create empty multibinder in case no ModelConverter bindings exist
-    Multibinder<ModelConverter> swaggerModelConverterBinder = Multibinder.newSetBinder(
-        binder(), ModelConverter.class);
+    Multibinder.newSetBinder(binder(), ModelConverter.class);
 
     bind(SwaggerApiResource.class);
     bind(SwaggerUiResource.class);
@@ -87,8 +80,6 @@ public class SwaggerModule extends AbstractModule {
     bind(JaxrsScanner.class).to(SwaggerGuiceJaxrsScanner.class);
 
     bind(SwaggerLifecycleHook.class).asEagerSingleton();
-
-    install(MultibindingsScanner.asModule());
   }
 
   static class SwaggerLifecycleHook {

--- a/swagger1/src/test/scala/com/cerner/beadledom/swagger/SwaggerModuleSpec.scala
+++ b/swagger1/src/test/scala/com/cerner/beadledom/swagger/SwaggerModuleSpec.scala
@@ -7,7 +7,7 @@ import com.wordnik.swagger.converter.ModelConverter
 import com.wordnik.swagger.model.Model
 
 /**
-  * Spec tests for {@link SwaggerModule}
+ * Spec tests for [[SwaggerModule]]
   */
 class SwaggerModuleSpec extends UnitSpec {
   val swaggerMockModule = new AbstractModule {
@@ -26,6 +26,12 @@ class SwaggerModuleSpec extends UnitSpec {
     }
   }
 
+  val swaggerMockModuleNoMultibinderDependency = new AbstractModule {
+    override def configure(): Unit = {
+      install(new SwaggerModule)
+    }
+  }
+
   describe("SwaggerModule") {
     it("Adds dependencies to the multibinder") {
       val setType = new TypeLiteral[java.util.Set[ModelConverter]] {}
@@ -33,6 +39,14 @@ class SwaggerModuleSpec extends UnitSpec {
       val dependencies = injector.getInstance(Key.get(setType))
 
       dependencies must have size 2
+    }
+
+    it("Creates empty multibinder if no dependencies exist") {
+      val setType = new TypeLiteral[java.util.Set[ModelConverter]] {}
+      val injector = Guice.createInjector(swaggerMockModuleNoMultibinderDependency)
+      val dependencies = injector.getInstance(Key.get(setType))
+
+      dependencies mustBe empty
     }
   }
 }

--- a/swagger2/src/main/java/com/cerner/beadledom/swagger2/Swagger2Module.java
+++ b/swagger2/src/main/java/com/cerner/beadledom/swagger2/Swagger2Module.java
@@ -1,7 +1,7 @@
 package com.cerner.beadledom.swagger2;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.multibindings.MultibindingsScanner;
+import com.google.inject.multibindings.Multibinder;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.config.JaxrsScanner;
@@ -45,11 +45,6 @@ import javax.inject.Inject;
  * <p>You may also supply set bindings for {@link io.swagger.converter.ModelConverter}.
  * These will be added to the list of model converters (before the default converter, but otherwise
  * in unspecified order).
- *
- * <p>Installs:
- * <ul>
- *   <li> {@link MultibindingsScanner} </li>
- * </ul>
  */
 public class Swagger2Module extends AbstractModule {
   @Override
@@ -64,6 +59,9 @@ public class Swagger2Module extends AbstractModule {
     bind(JaxrsScanner.class).to(SwaggerGuiceJaxrsScanner.class);
 
     bind(SwaggerLifecycleHook.class).asEagerSingleton();
+
+    // Create empty multibinder in case no ModelConverter bindings exist
+    Multibinder.newSetBinder(binder(), ModelConverter.class);
   }
 
   static class SwaggerLifecycleHook {

--- a/swagger2/src/test/scala/com/cerner/beadledom/swagger2/SwaggerModuleSpec.scala
+++ b/swagger2/src/test/scala/com/cerner/beadledom/swagger2/SwaggerModuleSpec.scala
@@ -11,7 +11,7 @@ import java.lang.reflect.Type
 import java.util
 
 /**
- * Spec tests for [Swagger2Module].
+ * Spec tests for [[Swagger2Module]].
  */
 class SwaggerModuleSpec extends UnitSpec {
   val swaggerMockModule = new AbstractModule {
@@ -30,6 +30,12 @@ class SwaggerModuleSpec extends UnitSpec {
     }
   }
 
+  val swaggerMockModuleNoMultibinderDependency = new AbstractModule {
+    override def configure(): Unit = {
+      install(new Swagger2Module)
+    }
+  }
+
   describe("SwaggerModule") {
     it("Adds dependencies to the multibinder") {
       val setType = new TypeLiteral[java.util.Set[ModelConverter]] {}
@@ -37,6 +43,14 @@ class SwaggerModuleSpec extends UnitSpec {
       val dependencies = injector.getInstance(Key.get(setType))
 
       dependencies must have size 2
+    }
+
+    it("Creates empty multibinder if no dependencies exist") {
+      val setType = new TypeLiteral[java.util.Set[ModelConverter]] {}
+      val injector = Guice.createInjector(swaggerMockModuleNoMultibinderDependency)
+      val dependencies = injector.getInstance(Key.get(setType))
+
+      dependencies mustBe empty
     }
   }
 }


### PR DESCRIPTION
### What was changed? Why is this necessary?

Fixing a defect with swagger2 module where no default implementation of ModelConverter was bound.


### How was it tested?
Consumed SNAPSHOT version in another service


### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
