### PR TITLE
Uplift spotbug to 3.1.8 to eliminate incorrect bug identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 3.2.1 - 3 December 2018
+
+### Defects Corrected
+* [internal] Upgrade to spotbug 3.1.8 to eliminate incorrect identification of bugs that was causing Travis to fail. [More Info](https://github.com/spotbugs/spotbugs/pull/688)
+
 ## 3.2 - 30 November 2018
 
 ### Additions

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.9.6</jackson.version>
     <resteasy.version>3.6.0.Final</resteasy.version>
-    <spotbugs.version>3.1.6</spotbugs.version>
+    <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
     <swagger-core.version>1.3.12</swagger-core.version>
     <swagger2-core.version>1.5.21</swagger2-core.version>


### PR DESCRIPTION
### What was changed? Why is this necessary?

The Travis CI build was failing because the log file is too long. One of the longest parts was caused by this 
![this](https://user-images.githubusercontent.com/11669595/49395729-e93bc500-f6fc-11e8-941c-b59d3c3d4f30.png)
which was found to be a defect in 3.1.6 spotbugs, and then subsequently fixed in 3.1.8. Hopefully this will be enough reduction in our logs to have travis pass.


### How was it tested?

I ran `mvn compile spotbugs:check` and made sure none of the previous spotbug errors occurred.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
