### PR TITLE
Fix site log length

### DIFF
--- a/.travis/publish_site.sh
+++ b/.travis/publish_site.sh
@@ -84,10 +84,10 @@ else
 fi
 
 printf "${CYAN}Generating site.$RESET \n"
-./mvnw clean site
+./mvnw clean site -B
 
 printf "${CYAN}Staging site.$RESET \n"
-./mvnw site:stage
+./mvnw site:stage -B
 
 printf "${CYAN}Checking out gh-pages branch.$RESET \n"
 git remote set-branches --add origin gh-pages && git fetch -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 3.2.2 - 4 December 2018
+
+### Defects Corrected
+* [internal] Use the `-B` option on our `mvn site` command to reduce log length by eliminating progress dialogs from downloads. [More Info](https://stackoverflow.com/questions/21638697/disable-maven-download-progress-indication) 
+
 ## 3.2.1 - 3 December 2018
 
 ### Defects Corrected


### PR DESCRIPTION
### What was changed? Why is this necessary?

The Travis logs were once again too long. A major culprit of log length is progress updates when downloading external maven packages.
![download](https://user-images.githubusercontent.com/11669595/49406061-15197380-f71a-11e8-9ad4-5f4cb4c6a1af.png)

This change enables batch mode on the site generation (it was already enabled on the main mvn install). Batch mode will eliminate these progress updates from our log and hopefully will make it short enough.

### How was it tested?

The Progress updates themselves don't actually print to terminal when we are developing locally, but you can see them flash up on the bottom of the screen. Before the change I could see them briefly but after the change I couldn't see them at all. 

Also, the fact that when the `mvn install` command runs (with the batch option enabled) there are none of these progress updates in the output provided me with more confidence that I was making the right change.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
