### PR TITLE
Add quiet run to site generate command

### DIFF
--- a/.travis/publish_site.sh
+++ b/.travis/publish_site.sh
@@ -84,7 +84,7 @@ else
 fi
 
 printf "${CYAN}Generating site.$RESET \n"
-./mvnw clean site -B
+./mvnw clean site -B -q
 
 printf "${CYAN}Staging site.$RESET \n"
 ./mvnw site:stage -B

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 3.2.3 - 4 December 2018
+
+### Defects Corrected
+* [internal] Use the `-q` option on `mvn site` to enable quiet running of the command (only printing errors) in an effort to reduce log length in Travis.
+
 ## 3.2.2 - 4 December 2018
 
 ### Defects Corrected


### PR DESCRIPTION
### What was changed? Why is this necessary?

The mvn site command was given the -q switch, which enables quiet mode. This will only let it output errors. This change was necessary because the site generation is what takes up the most of our logs, and this should help fix that issue. We will still print out errors, but prior to this change we were printing out `Forking ...` for each of our projects when we were building each of the projects for a total print out of 1,764 blocks that just tell us we are `Forking` other projects. 

### How was it tested?

I ran the site command with and without the flag to verify that the output was shorter.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
