### PR TITLE
Changing jackson version to 2.9.8 to fix vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Beadledom Changelog
 
+## 3.2.4 - In development
+
+### Defects Corrected
+* Jackson version uplift from 2.9.6 -> 2.9.8 because of vulnerabilities: 
+  - CVE-2018-19360
+  - CVE-2018-19362
+  - CVE-2018-14720
+  - CVE-2018-19361
+  - CVE-2018-14719
+  - CVE-2018-14718
+  - CVE-2018-14721
+
 ## 3.2.3 - 4 December 2018
 
 ### Defects Corrected

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.5</governator.version>
-    <jackson.version>2.9.6</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <resteasy.version>3.6.0.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>


### PR DESCRIPTION
### What was changed? Why is this necessary?
Jackson databind has high severity security vulnerabilities as outlined here:

https://nvd.nist.gov/vuln/detail/CVE-2018-19360
https://nvd.nist.gov/vuln/detail/CVE-2018-19362
https://nvd.nist.gov/vuln/detail/CVE-2018-14720
https://nvd.nist.gov/vuln/detail/CVE-2018-19361
https://nvd.nist.gov/vuln/detail/CVE-2018-14719
https://nvd.nist.gov/vuln/detail/CVE-2018-14718
https://nvd.nist.gov/vuln/detail/CVE-2018-14721

this upgrades the version to a version without the vulnerabilities 

### How was it tested?

mvn clean install the project

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
