### PR TITLE
Remove jersey-media-multipart exclusion from swagger-jersey2-jaxrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Beadledom Changelog
 
-## 3.3 - In Development
+## 3.2.5 - 25 March 2019
+
+### Defects Corrected
+* Add back `jersey-media-multipart` with an explicit version (turns out `swagger-jersey2-jaxrs` requires it).
 
 ## 3.2.4 - 22 March 2019
 

--- a/pom.xml
+++ b/pom.xml
@@ -368,10 +368,6 @@
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet-core</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-multipart</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -456,6 +452,11 @@
         <artifactId>tomcat-embed-jasper</artifactId>
         <version>${tomcat-embed.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-multipart</artifactId>
+        <version>2.28</version>
       </dependency>
       <!-- If this version is updated the WEBJAR_PATH in SwaggerUiResource must also be updated -->
       <dependency>
@@ -994,7 +995,7 @@
         <version>${maven-project-info-reports-plugin.version}</version>
         <reportSets>
           <reportSet>
-            <reports />
+            <reports/>
           </reportSet>
         </reportSets>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
     <swagger-core.version>1.3.12</swagger-core.version>
-    <swagger2-core.version>1.5.21</swagger2-core.version>
+    <swagger2-core.version>1.5.22</swagger2-core.version>
     <tomcat-embed.version>7.0.91</tomcat-embed.version>
     <wagon.version>2.10</wagon.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>


### PR DESCRIPTION
### What was changed? Why is this necessary?

Removes the exclusion of `jersey-media-multipart`. Turns out `swagger-jersey2-jaxrs` has an explicit dependency on this just for checking if it should be ignored: https://github.com/swagger-api/swagger-core/blob/v1.5.22/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/SwaggerJersey2Jaxrs.java#L71


### How was it tested?

Ran existing tests.


### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
