### PR TITLE
Add Jooq transaction hooks for executing actions on commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Beadledom Changelog
 
-## 3.2.6 - In Development
-* Added archetype for project generation.
-* Updated client documentation to recommend using an abstracted resource pattern.
+## [3.3] - In Development
+
+### Added
+
+* Jooq transaction hooks for executing actions after a successful commit.
+
+### Changed
+* Switch to Keep a Changelog style for Changelog moving forward - https://keepachangelog.com/en/1.0.0/
+* Update maven archetype for project generation with new client recommendations.
+* Update client documentation to recommend using an abstracted resource pattern.
 
 ## 3.2.5 - 25 March 2019
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,4 +16,12 @@
     <gav regex="true">^org\.tukaani:xz:.*$</gav>
     <cve>CVE-2015-4035</cve>
   </suppress>
+  <!-- TODO: Remove after Jackson 2.9.9.1 is released and we have updated -->
+  <suppress>
+    <notes><![CDATA[
+   file name: jackson-databind-2.9.9.jar
+   ]]></notes>
+    <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
+    <cve>CVE-2019-12814</cve>
+  </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -16,12 +16,4 @@
     <gav regex="true">^org\.tukaani:xz:.*$</gav>
     <cve>CVE-2015-4035</cve>
   </suppress>
-  <!-- Vulnerability fix for auto-value is not released yet so we need to suppress it for the time being -->
-  <suppress>
-    <notes><![CDATA[
-   file name: auto-value-1.6.2.jar/META-INF/maven/com.google.guava/guava/pom.xml
-   ]]></notes>
-    <filePath regex="true">.*auto-value-1.6.2\.jar.*$</filePath>
-    <cpe>cpe:/a:google:guava</cpe>
-  </suppress>
 </suppressions>

--- a/docs/source/manual/jooq.rst
+++ b/docs/source/manual/jooq.rst
@@ -112,9 +112,78 @@ Below is an example of configuring the required binding uses a C3P0 pooling data
     }
   }
 
+Post commit actions
+~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you need to perform an action only after the current transaction successfully commits. For example,
+updating or invalidating a cache.
+
+The JooqTransactionalHooks_ class provides the :code:`whenCommitted` method for registering callback actions that should be executed after a transaction is successfully committed. Any no-arguments lambda expression or :code:`Runnable` implementation can be passed as the action.
+
+.. code-block:: java
+
+  hooks.whenCommitted(() -> cache.invalidate())
+
+The action you register will be called immediately after the current transaction is successfully committed.
+
+If you call :code:`whenCommitted` while there isn't an active transaction, the action will be executed immediately.
+
+If the current transaction is rolled back instead of committed, then your action will be discarded and never called.
+
+Nested Transactions
+"""""""""""""""""""
+
+Nested transactions (savepoints) are handled correctly. Actions registered via :code:`whenCommitted` in a nested transaction will only be called after the outermost transaction is committed, and will not be called if a rollback to any outer savepoint occurs during the transaction.
+
+.. code-block:: java
+
+  @JooqTransactional
+  public void outer() {
+    hooks.whenCommitted(() -> foo());
+    inner();
+  }
+
+  @JooqTransactional {
+  public void inner {
+    hooks.WhenCommitted(() -> bar());
+  }
+
+  // foo() and then bar() will be called when the outer transaction is committed.
+
+.. code-block:: java
+
+  @JooqTransactional
+  public void outer() {
+    hooks.whenCommitted(() -> foo());
+    try {
+      inner();
+    } catch(Exception e) {
+      // Log or handle exception, but since we caught the inner exception the outer transaction will not be rolled back.
+    }
+  }
+
+  @JooqTransactional {
+  public void inner {
+    hooks.WhenCommitted(() -> bar());
+    throw new RuntimeException();  // Raising an exception will cause this inner transaction to rollback.
+  }
+
+  // foo() will be called, but not bar()
+
+Order of Execution
+""""""""""""""""""
+
+Actions registered with :code:`whenCommitted` for a given transaction are executed in the ordered they were registered.
+
+Exception Handling
+""""""""""""""""""
+
+If an action registered with :code:`whenCommitted` for a given transactions throws an exception, then no later registered actions in the same transaction will be called. Since the callback actions are executed *after* a successful commit, an exception in a callback will not cause the transaction to roll back.
+
 .. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
 .. _DSLContext: https://www.jooq.org/javadoc/latest/org/jooq/DSLContext.html
 .. _DSLContextProvider: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProvider.java
 .. _JooqTransactional: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactional.java
 .. _SQLDialect: https://www.jooq.org/javadoc/latest/org/jooq/SQLDialect.html
 .. _ThreadLocalJooqModule: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqModule.java
+.. _JooqTransactionalHooks:https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooqs.java

--- a/docs/source/manual/jooq.rst
+++ b/docs/source/manual/jooq.rst
@@ -145,7 +145,7 @@ Nested transactions (savepoints) are handled correctly. Actions registered via :
 
   @JooqTransactional {
   public void inner {
-    hooks.WhenCommitted(() -> bar());
+    hooks.whenCommitted(() -> bar());
   }
 
   // foo() and then bar() will be called when the outer transaction is committed.
@@ -164,7 +164,7 @@ Nested transactions (savepoints) are handled correctly. Actions registered via :
 
   @JooqTransactional {
   public void inner {
-    hooks.WhenCommitted(() -> bar());
+    hooks.whenCommitted(() -> bar());
     throw new RuntimeException();  // Raising an exception will cause this inner transaction to rollback.
   }
 

--- a/docs/source/manual/jooq.rst
+++ b/docs/source/manual/jooq.rst
@@ -180,6 +180,13 @@ Exception Handling
 
 If an action registered with :code:`whenCommitted` for a given transactions throws an exception, then no later registered actions in the same transaction will be called. Since the callback actions are executed *after* a successful commit, an exception in a callback will not cause the transaction to roll back.
 
+Why no rollback hooks?
+""""""""""""""""""""""
+
+Rollback hooks are more difficult to implement robustly. A variety of things can cause an implicit rollback. For instance, if your process is killed, in the middle of a transaction, without a graceful shutdown, your rollback hooks would not run.
+
+Instead of using a rollback hook, try to invert what you are trying to do. Instead of trying to undo something when a transaction fails, instead use a commit hook to delay doing something until after the transaction succeeds.
+
 .. _DataSource: https://docs.oracle.com/javase/8/docs/api/javax/sql/DataSource.html
 .. _DSLContext: https://www.jooq.org/javadoc/latest/org/jooq/DSLContext.html
 .. _DSLContextProvider: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProvider.java

--- a/docs/source/manual/jooq.rst
+++ b/docs/source/manual/jooq.rst
@@ -133,7 +133,7 @@ If the current transaction is rolled back instead of committed, then your action
 Nested Transactions
 """""""""""""""""""
 
-Nested transactions (savepoints) are handled correctly. Actions registered via :code:`whenCommitted` in a nested transaction will only be called after the outermost transaction is committed, and will not be called if a rollback to any outer savepoint occurs during the transaction.
+Actions registered via :code:`whenCommitted` in a nested transaction will only be called after the outermost transaction is committed, and will not be called if a rollback to any outer savepoint occurs during the transaction.
 
 .. code-block:: java
 

--- a/docs/source/manual/jooq.rst
+++ b/docs/source/manual/jooq.rst
@@ -193,4 +193,4 @@ Instead of using a rollback hook, try to invert what you are trying to do. Inste
 .. _JooqTransactional: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactional.java
 .. _SQLDialect: https://www.jooq.org/javadoc/latest/org/jooq/SQLDialect.html
 .. _ThreadLocalJooqModule: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqModule.java
-.. _JooqTransactionalHooks:https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooqs.java
+.. _JooqTransactionalHooks: https://github.com/cerner/beadledom/tree/master/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooqs.java

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProviderImpl.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProviderImpl.java
@@ -22,11 +22,14 @@ class DSLContextProviderImpl implements DSLContextProvider, UnitOfWork {
   private final ThreadLocal<DSLContext> dslContexts = new ThreadLocal<>();
 
   @Inject
-  DSLContextProviderImpl(DataSource dataSource, SQLDialect sqlDialect) {
-    // ThreadLocalTransactionProvider handles all of the ThreadLocal semantics for us
+  DSLContextProviderImpl(
+      DataSource dataSource, SQLDialect sqlDialect, JooqTransactionalHooks transactionalHooks) {
+    // ThreadLocalTransactionProvider and ThreadLocalCommitHookExecutingTransactionListener handle
+    // all of the ThreadLocal semantics of Jooq and Transaction hooks for us.
     this.configuration = new DefaultConfiguration()
         .set(sqlDialect)
-        .set(new ThreadLocalTransactionProvider(new DataSourceConnectionProvider(dataSource)));
+        .set(new ThreadLocalTransactionProvider(new DataSourceConnectionProvider(dataSource)))
+        .set(new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks));
   }
 
   @Override

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProviderImpl.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProviderImpl.java
@@ -23,7 +23,8 @@ class DSLContextProviderImpl implements DSLContextProvider, UnitOfWork {
 
   @Inject
   DSLContextProviderImpl(
-      DataSource dataSource, SQLDialect sqlDialect, JooqTransactionalHooks transactionalHooks) {
+      DataSource dataSource, SQLDialect sqlDialect,
+      ThreadLocalJooqTransactionalHooks transactionalHooks) {
     // ThreadLocalTransactionProvider and ThreadLocalCommitHookExecutingTransactionListener handle
     // all of the ThreadLocal semantics of Jooq and Transaction hooks for us.
     this.configuration = new DefaultConfiguration()

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransaction.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransaction.java
@@ -1,0 +1,39 @@
+package com.cerner.beadledom.jooq;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A representation of a Jooq Transaction with post-commit hooks and nested transactions.
+ *
+ * @author John Leacox
+ * @since 3.3
+ */
+class JooqTransaction {
+  private final List<Runnable> commitHooks = new ArrayList<>();
+  private final List<JooqTransaction> nestedTransactions = new ArrayList<>();
+
+  void addCommitHook(Runnable action) {
+    commitHooks.add(action);
+  }
+
+  List<Runnable> getCommitHooks() {
+    return commitHooks;
+  }
+
+  void addNestedTransaction(JooqTransaction nested) {
+    nestedTransactions.add(nested);
+  }
+
+  List<JooqTransaction> getNestedTransactions() {
+    return nestedTransactions;
+  }
+
+  void clearCommitHooks() {
+    commitHooks.clear();
+  }
+
+  void clearNestedTransaction() {
+    nestedTransactions.clear();
+  }
+}

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooks.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooks.java
@@ -6,7 +6,7 @@ package com.cerner.beadledom.jooq;
  * @author John Leacox
  * @since 3.3
  */
-public abstract class JooqTransactionalHooks {
+public interface JooqTransactionalHooks {
   /**
    * Registers an action to be executed when the current Jooq transaction is successfully committed.
    *
@@ -45,11 +45,5 @@ public abstract class JooqTransactionalHooks {
    * @param action the action to be executed upon the successful commit of the current Jooq
    *     transaction
    */
-  public abstract void whenCommitted(Runnable action);
-
-  void setTransaction(JooqTransaction transaction) {
-  }
-
-  void clearTransaction() {
-  }
+  void whenCommitted(Runnable action);
 }

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooks.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/JooqTransactionalHooks.java
@@ -1,0 +1,55 @@
+package com.cerner.beadledom.jooq;
+
+/**
+ * Transaction callback hooks to be executed when the current Jooq transaction completes.
+ *
+ * @author John Leacox
+ * @since 3.3
+ */
+public abstract class JooqTransactionalHooks {
+  /**
+   * Registers an action to be executed when the current Jooq transaction is successfully committed.
+   *
+   * <p>
+   * If this method is called while a Jooq transaction is not active, the action will be executed
+   * immediately.
+   * </p>
+   *
+   * <p>
+   * If the current Jooq transaction is rolled back instead of committed, then the action will be
+   * discarded and never called.
+   * </p>
+   *
+   * <h3>Savepoints / Nested Transactions</h3>
+   *
+   * <p>
+   * Actions registered on nested transaction (or savepoints) will be called after the top-level
+   * transaction is committed, but not if a rollback to the savepoint or any parent savepoint
+   * occurred during the transaction. When a savepoint is rolled back the commit hooks associated
+   * with that savepoint or further nested savepoints will not be executed. However, commit hooks
+   * associated with savepoints at a higher level of nesting than the rollback, will be executed if
+   * the top-level transaction commits.
+   * </p>
+   *
+   * <h3>Order of Execution</h3>
+   *
+   * <p>The callback actions will be executed in the order they are registered.</p>
+   *
+   * <h3>Exception Handling</h3>
+   *
+   * <p>
+   * If a callback action throws an exception, no later registered callbacks in the same
+   * transaction will be executed.
+   * </p>
+   *
+   * @param action the action to be executed upon the successful commit of the current Jooq
+   *     transaction
+   */
+  public abstract void whenCommitted(Runnable action);
+
+  void setTransaction(JooqTransaction transaction) {
+  }
+
+  void clearTransaction() {
+  }
+}

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListener.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListener.java
@@ -17,11 +17,10 @@ import org.jooq.impl.DefaultTransactionListener;
 class ThreadLocalCommitHookExecutingTransactionListener extends DefaultTransactionListener {
   private final ThreadLocal<Deque<JooqTransaction>> transactionDeques = new ThreadLocal<>();
 
-  // This assumes that the hooks implementation is using ThreadLocal or some other means to have
-  // the same lifecycle as this listener.
-  private final JooqTransactionalHooks transactionalHooks;
+  private final ThreadLocalJooqTransactionalHooks transactionalHooks;
 
-  ThreadLocalCommitHookExecutingTransactionListener(JooqTransactionalHooks transactionalHooks) {
+  ThreadLocalCommitHookExecutingTransactionListener(
+      ThreadLocalJooqTransactionalHooks transactionalHooks) {
     this.transactionalHooks = transactionalHooks;
   }
 

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListener.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListener.java
@@ -1,0 +1,117 @@
+package com.cerner.beadledom.jooq;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import org.jooq.TransactionContext;
+import org.jooq.TransactionListener;
+import org.jooq.impl.DefaultTransactionListener;
+
+/**
+ * An implementation of {@link TransactionListener} that sets the current transaction for
+ * {@link JooqTransactionalHooks} and removes hooks on rollback or executes commit hooks when the
+ * top-level transaction is committed.
+ *
+ * @author John Leacox
+ * @since 3.3
+ */
+class ThreadLocalCommitHookExecutingTransactionListener extends DefaultTransactionListener {
+  private final ThreadLocal<Deque<JooqTransaction>> transactionDeques = new ThreadLocal<>();
+
+  // This assumes that the hooks implementation is using ThreadLocal or some other means to have
+  // the same lifecycle as this listener.
+  private final JooqTransactionalHooks transactionalHooks;
+
+  ThreadLocalCommitHookExecutingTransactionListener(JooqTransactionalHooks transactionalHooks) {
+    this.transactionalHooks = transactionalHooks;
+  }
+
+  @Override
+  public void beginEnd(TransactionContext ctx) {
+    JooqTransaction transaction = new JooqTransaction();
+
+    Deque<JooqTransaction> transactions = transactions();
+    JooqTransaction parentTransaction = transactions.peekLast();
+    if (parentTransaction != null) {
+      parentTransaction.addNestedTransaction(transaction);
+    }
+
+    // Jooq provides the ability to store a custom transaction on the context via ctx#transaction(),
+    // however this doesn't provide the ability to know when a transaction event is being called
+    // on the top-level transaction vs nested transactions. Since we only want to run commit hooks
+    // when the top-level transaction is committed, we must track the transaction nesting level
+    // ourselves.
+    transactions.push(transaction);
+    transactionalHooks.setTransaction(transaction);
+  }
+
+  @Override
+  public void commitEnd(TransactionContext ctx) {
+    Deque<JooqTransaction> transactions = transactions();
+    JooqTransaction transaction = transactions.pop();
+
+    // This is the top-level transaction
+    if (transactions.isEmpty()) {
+      try {
+        executeCommitHooks(transaction);
+      } finally {
+        clear();
+      }
+    }
+  }
+
+  @Override
+  public void rollbackEnd(TransactionContext ctx) {
+    Deque<JooqTransaction> transactions = transactions();
+    JooqTransaction transaction = transactions.pop();
+
+    transaction.clearCommitHooks();
+    transaction.clearNestedTransaction();
+
+    // This is the top-level transaction
+    if (transactions.isEmpty()) {
+      clear();
+    }
+  }
+
+  /**
+   * Returns the Deque of nested transactions associated to the current thread.
+   */
+  private Deque<JooqTransaction> transactions() {
+    Deque<JooqTransaction> result = transactionDeques.get();
+
+    if (result == null) {
+      result = new ArrayDeque<>();
+      transactionDeques.set(result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Executes the commit hooks associated with the transaction and all nested transaction hooks.
+   *
+   * <p>
+   * If a commit hook throws an exception, the commit hook execution chain will be stopped
+   * immediately, and no later registered commit hooks in that same transaction will be executed.
+   * </p>
+   *
+   * @param transaction the transaction to execute commit hooks for.
+   */
+  private void executeCommitHooks(JooqTransaction transaction) {
+    for (Runnable commitHook : transaction.getCommitHooks()) {
+      commitHook.run();
+    }
+
+    for (JooqTransaction nested : transaction.getNestedTransactions()) {
+      executeCommitHooks(nested);
+    }
+  }
+
+  /**
+   * Clears the nested transaction hooks and transactions Deque.
+   */
+  private void clear() {
+    transactionalHooks.clearTransaction();
+    transactionDeques.remove();
+  }
+}

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqModule.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqModule.java
@@ -11,15 +11,19 @@ import org.jooq.SQLDialect;
 /**
  * A guice module that configures the Jooq DSLContext and Jooq Transactions.
  *
- * <p>The configured DSLContexts and transactions will be scoped by thread. This means that this
+ * <p>
+ * The configured DSLContexts and transactions will be scoped by thread. This means that this
  * module should only be used if it is guaranteed that database transactions and contexts will
  * never cross thread boundaries.
+ * </p>
  *
- * <p>Provides:
- * <ul>
+ * <p>
+ * Provides:
+ *   <ul>
  *     <li>{@link DSLContextProvider}</li>
  *     <li>{@link JooqTransactional} AOP interceptor</li>
- * </ul>
+ *   </ul>
+ * </p>
  *
  * @author John Leacox
  * @since 2.7
@@ -29,6 +33,10 @@ public class ThreadLocalJooqModule extends AbstractModule {
   protected void configure() {
     requireBinding(DataSource.class);
     requireBinding(SQLDialect.class);
+
+    bind(JooqTransactionalHooks.class)
+        .to(ThreadLocalJooqTransactionalHooks.class)
+        .in(Singleton.class);
 
     bind(DSLContextProviderImpl.class).in(Singleton.class);
     bind(DSLContextProvider.class).to(DSLContextProviderImpl.class);

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqModule.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqModule.java
@@ -34,6 +34,7 @@ public class ThreadLocalJooqModule extends AbstractModule {
     requireBinding(DataSource.class);
     requireBinding(SQLDialect.class);
 
+    bind(ThreadLocalJooqTransactionalHooks.class).in(Singleton.class);
     bind(JooqTransactionalHooks.class)
         .to(ThreadLocalJooqTransactionalHooks.class)
         .in(Singleton.class);

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooks.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooks.java
@@ -1,0 +1,36 @@
+package com.cerner.beadledom.jooq;
+
+import java.util.Objects;
+
+/**
+ * An implementation of {@link JooqTransactionalHooks} that uses {@link ThreadLocal} to track the
+ * current transaction nesting.
+ *
+ * @author John Leacox
+ * @since 3.3
+ */
+class ThreadLocalJooqTransactionalHooks extends JooqTransactionalHooks {
+  private ThreadLocal<JooqTransaction> transactions = new ThreadLocal<>();
+
+  @Override
+  public void whenCommitted(Runnable action) {
+    Objects.requireNonNull(action);
+
+    JooqTransaction transaction = transactions.get();
+
+    if (transaction == null) {
+      action.run();
+      return;
+    }
+
+    transaction.addCommitHook(action);
+  }
+
+  void setTransaction(JooqTransaction transaction) {
+    transactions.set(transaction);
+  }
+
+  void clearTransaction() {
+    transactions.remove();
+  }
+}

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooks.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooks.java
@@ -9,7 +9,7 @@ import java.util.Objects;
  * @author John Leacox
  * @since 3.3
  */
-class ThreadLocalJooqTransactionalHooks extends JooqTransactionalHooks {
+class ThreadLocalJooqTransactionalHooks implements JooqTransactionalHooks {
   private ThreadLocal<JooqTransaction> transactions = new ThreadLocal<>();
 
   @Override

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
@@ -13,7 +13,11 @@ import scala.collection.mutable
  */
 class DSLContextProviderImplSpec extends
     FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
-  val transactionalHooks = mock[JooqTransactionalHooks]
+  val transactionalHooks = new ThreadLocalJooqTransactionalHooks()
+
+  before {
+    transactionalHooks.clearTransaction()
+  }
 
   describe("DSLContextProviderImpl") {
     describe("#isActive") {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
@@ -4,6 +4,7 @@ import javax.sql.DataSource
 import org.jooq.{DSLContext, SQLDialect}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import scala.collection.mutable
 
 /**
  * Spec for DSLContextProviderImpl.
@@ -12,11 +13,13 @@ import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
  */
 class DSLContextProviderImplSpec extends
     FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+  val transactionalHooks = mock[JooqTransactionalHooks]
+
   describe("DSLContextProviderImpl") {
     describe("#isActive") {
       it("must return false on a new instance") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.isActive mustBe false
       }
@@ -25,7 +28,7 @@ class DSLContextProviderImplSpec extends
     describe("#end") {
       it("must do nothing if it is not active") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.end()
         provider.isActive mustBe false
@@ -35,7 +38,7 @@ class DSLContextProviderImplSpec extends
     describe("#begin") {
       it("must be active after starting") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.begin()
         provider.isActive mustBe true
@@ -43,7 +46,7 @@ class DSLContextProviderImplSpec extends
 
       it("must not be active after starting and stopping") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.begin()
         provider.end()
@@ -52,7 +55,7 @@ class DSLContextProviderImplSpec extends
 
       it("must throw an IllegalStateException if it is already active") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.begin()
         intercept[IllegalStateException] {
@@ -62,7 +65,7 @@ class DSLContextProviderImplSpec extends
 
       it("must allow restarting after stopping") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.begin()
         provider.end()
@@ -72,7 +75,7 @@ class DSLContextProviderImplSpec extends
 
       it("must be scoped by thread; allow starting from multiple threads") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         val runnable = new Runnable() {
           override def run(): Unit = {
@@ -82,16 +85,21 @@ class DSLContextProviderImplSpec extends
           }
         }
 
+        val threads = mutable.ListBuffer[Thread]()
         for (_ <- 1 to 5) {
-          new Thread(runnable).start()
+          val thread = new Thread(runnable)
+          threads += thread
+          thread.start()
         }
+
+        threads.foreach { t => t.join(5000) }
       }
     }
 
     describe("#get") {
       it("must return an a DSLContext if it is active") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         provider.begin()
         val dslContext = provider.get()
@@ -100,7 +108,7 @@ class DSLContextProviderImplSpec extends
 
       it("must throw an IllegalStateException if it is not active") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         intercept[IllegalStateException] {
           provider.get()
@@ -109,7 +117,7 @@ class DSLContextProviderImplSpec extends
 
       it("must return the same DSLContext on the same thread") {
         val dataSource = mock[DataSource]
-        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL)
+        val provider = new DSLContextProviderImpl(dataSource, SQLDialect.MYSQL, transactionalHooks)
 
         val runnable = new Runnable() {
           override def run(): Unit = {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTransactionSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTransactionSpec.scala
@@ -1,0 +1,109 @@
+package com.cerner.beadledom.jooq
+
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+
+/**
+ * Spec for JooqTransaction.
+ *
+ * @author John Leacox
+ */
+class JooqTransactionSpec extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+  describe("JooqTransaction") {
+    describe("#addCommitHooks") {
+      it("adds the actions to the transactions commit hooks") {
+        val transaction = new JooqTransaction()
+
+        val actionOne = new Runnable {
+          override def run(): Unit = ???
+        }
+        transaction.addCommitHook(actionOne)
+
+        val actionTwo = new Runnable {
+          override def run(): Unit = ???
+        }
+        transaction.addCommitHook(actionTwo)
+
+        val hooks = transaction.getCommitHooks
+
+        hooks must have size 2
+        hooks must contain(actionOne)
+        hooks must contain(actionTwo)
+      }
+    }
+
+    describe("#getCommitHooks") {
+      describe("when no actions have been added") {
+        it("returns an empty list") {
+          val transaction = new JooqTransaction()
+
+          transaction.getCommitHooks must have size 0
+        }
+      }
+    }
+
+    describe("#addNestedTransaction") {
+      it("adds the transaction to the nested transactions") {
+        val transaction = new JooqTransaction()
+
+        val nestedOne = new JooqTransaction()
+        transaction.addNestedTransaction(nestedOne)
+
+        val nestedTwo = new JooqTransaction()
+        transaction.addNestedTransaction(nestedTwo)
+
+        val nested = transaction.getNestedTransactions
+
+        nested must have size 2
+        nested must contain(nestedOne)
+        nested must contain(nestedTwo)
+      }
+    }
+
+    describe("#getNestedTransaction") {
+      describe("when no nested transactions have been added") {
+        it("returns an empty list") {
+          val transaction = new JooqTransaction()
+
+          transaction.getNestedTransactions must have size 0
+        }
+      }
+    }
+
+    describe("#clearCommitHooks") {
+      it("removes all commit hooks") {
+        val transaction = new JooqTransaction()
+
+        val actionOne = new Runnable {
+          override def run(): Unit = ???
+        }
+        transaction.addCommitHook(actionOne)
+
+        val actionTwo = new Runnable {
+          override def run(): Unit = ???
+        }
+        transaction.addCommitHook(actionTwo)
+
+        transaction.clearCommitHooks()
+
+        transaction.getCommitHooks must have size 0
+      }
+    }
+
+    describe("#clearNestedTransaction") {
+      it("removes all nested transactions") {
+        val transaction = new JooqTransaction()
+
+        val nestedOne = new JooqTransaction()
+        transaction.addNestedTransaction(nestedOne)
+
+        val nestedTwo = new JooqTransaction()
+        transaction.addNestedTransaction(nestedTwo)
+
+        transaction.clearNestedTransaction()
+
+        transaction.getNestedTransactions must have size 0
+      }
+    }
+  }
+}

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
@@ -1,0 +1,175 @@
+package com.cerner.beadledom.jooq
+
+import org.jooq.TransactionContext
+import org.mockito.Mockito.reset
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+
+/**
+ * Spec for ThreadLocalCommitHookExecutingTransactionListener.
+ *
+ * @author John Leacox
+ */
+class ThreadLocalCommitHookExecutingTransactionListenerSpec
+    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+  val context = mock[TransactionContext]
+
+  val transactionalHooks = new ThreadLocalJooqTransactionalHooks
+
+  var actionExecutionOrderIndex = 0
+
+  var rootActionOneExecutionIndex = -1
+  val rootActionOne = new Runnable {
+    override def run(): Unit = {
+      rootActionOneExecutionIndex = actionExecutionOrderIndex
+      actionExecutionOrderIndex += 1
+    }
+  }
+
+  var nestedLevelOneActionOneExecutionIndex = -1
+  val nestedLevelOneActionOne = new Runnable {
+    override def run(): Unit = {
+      nestedLevelOneActionOneExecutionIndex = actionExecutionOrderIndex
+      actionExecutionOrderIndex += 1
+    }
+  }
+
+  var nestedLevelOneActionTwoExecutionIndex = -1
+  val nestedLevelOneActionTwo = new Runnable {
+    override def run(): Unit = {
+      nestedLevelOneActionTwoExecutionIndex = actionExecutionOrderIndex
+      actionExecutionOrderIndex += 1
+    }
+  }
+
+  var nestedLevelTwoActionOneExecutionIndex = -1
+  val nestedLevelTwoActionOne = new Runnable {
+    override def run(): Unit = {
+      nestedLevelTwoActionOneExecutionIndex = actionExecutionOrderIndex
+      actionExecutionOrderIndex += 1
+    }
+  }
+
+  before {
+    reset(context)
+
+    transactionalHooks.clearTransaction()
+
+    actionExecutionOrderIndex = 0
+    rootActionOneExecutionIndex = -1
+    nestedLevelOneActionOneExecutionIndex = -1
+    nestedLevelOneActionTwoExecutionIndex = -1
+    nestedLevelTwoActionOneExecutionIndex = -1
+  }
+
+  describe("ThreadLocalCommitHookExecutingTransactionListener") {
+    describe("when a transaction is committed") {
+      describe("when it is the root transaction") {
+        it("executes commit hooks in the order registered") {
+          val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
+
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(rootActionOne)
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(nestedLevelOneActionOne)
+
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
+          listener.commitEnd(context)
+
+          transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
+
+          listener.commitEnd(context)
+
+          rootActionOneExecutionIndex mustBe -1
+          nestedLevelOneActionOneExecutionIndex mustBe -1
+          nestedLevelOneActionTwoExecutionIndex mustBe -1
+          nestedLevelTwoActionOneExecutionIndex mustBe -1
+
+          listener.commitEnd(context)
+
+          rootActionOneExecutionIndex mustBe 0
+          nestedLevelOneActionOneExecutionIndex mustBe 1
+          nestedLevelOneActionTwoExecutionIndex mustBe 3
+          nestedLevelTwoActionOneExecutionIndex mustBe 2
+        }
+
+        describe("after a nested connection is rolled back") {
+          it("only executes commit hooks for the non-rolled back connections") {
+            val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
+
+            listener.beginEnd(context)
+            transactionalHooks.whenCommitted(rootActionOne)
+            listener.beginEnd(context)
+            transactionalHooks.whenCommitted(nestedLevelOneActionOne)
+            transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
+            listener.beginEnd(context)
+            transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
+
+            listener.rollbackEnd(context)
+            listener.commitEnd(context)
+
+            rootActionOneExecutionIndex mustBe -1
+            nestedLevelOneActionOneExecutionIndex mustBe -1
+            nestedLevelOneActionTwoExecutionIndex mustBe -1
+            nestedLevelTwoActionOneExecutionIndex mustBe -1
+
+            listener.commitEnd(context)
+
+            rootActionOneExecutionIndex mustBe 0
+            nestedLevelOneActionOneExecutionIndex mustBe 1
+            nestedLevelOneActionTwoExecutionIndex mustBe 2
+            nestedLevelTwoActionOneExecutionIndex mustBe -1
+          }
+        }
+      }
+
+      describe("when it is a nested transaction") {
+        it("does not execute commit hooks") {
+          val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
+
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(rootActionOne)
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(nestedLevelOneActionOne)
+          transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
+
+          listener.commitEnd(context)
+          listener.commitEnd(context)
+
+          rootActionOneExecutionIndex mustBe -1
+          nestedLevelOneActionOneExecutionIndex mustBe -1
+          nestedLevelOneActionTwoExecutionIndex mustBe -1
+          nestedLevelTwoActionOneExecutionIndex mustBe -1
+        }
+      }
+    }
+
+    describe("when a transaction is rolled back") {
+      describe("when it is the root transaction") {
+        it("does not execute commit hooks") {
+          val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
+
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(rootActionOne)
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(nestedLevelOneActionOne)
+          transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
+          listener.beginEnd(context)
+          transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
+
+          listener.rollbackEnd(context)
+          listener.rollbackEnd(context)
+          listener.rollbackEnd(context)
+
+          rootActionOneExecutionIndex mustBe -1
+          nestedLevelOneActionOneExecutionIndex mustBe -1
+          nestedLevelOneActionTwoExecutionIndex mustBe -1
+          nestedLevelTwoActionOneExecutionIndex mustBe -1
+        }
+      }
+    }
+  }
+}

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqModuleSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqModuleSpec.scala
@@ -87,6 +87,22 @@ class ThreadLocalJooqModuleSpec
           .map(c => c.toString)
           .find(s => s.contains("cglib")) mustBe defined
     }
+
+    it("binds JooqTransactionalHooks") {
+      val dataSource = mock[DataSource]
+
+      val module = new AbstractModule {
+        override def configure(): Unit = {
+          bind(classOf[DataSource]).toInstance(dataSource)
+          bind(classOf[SQLDialect]).toInstance(SQLDialect.MYSQL)
+
+          install(new ThreadLocalJooqModule)
+        }
+      }
+
+      val injector = Guice.createInjector(module)
+      injector.getInstance(classOf[JooqTransactionalHooks])
+    }
   }
 }
 

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooksSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooksSpec.scala
@@ -1,0 +1,135 @@
+package com.cerner.beadledom.jooq
+
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+
+/**
+ * Spec for ThreadLocalJooqTransactionalHooks.
+ *
+ * @author John Leacox
+ */
+class ThreadLocalJooqTransactionalHooksSpec
+    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+  describe("ThreadLocalJooqTransactionalHooks") {
+    describe("#whenCommitted") {
+      it("throws a NullPointerException if action is null") {
+        val hooks = new ThreadLocalJooqTransactionalHooks()
+
+        intercept[NullPointerException] {
+          hooks.whenCommitted(null)
+        }
+      }
+
+      describe("when a transaction is not active") {
+        it("executes the action immediately") {
+          val hooks = new ThreadLocalJooqTransactionalHooks()
+
+          var wasActionExecuted = false
+          hooks.whenCommitted(new Runnable {
+            override def run(): Unit = {
+              wasActionExecuted = true
+            }
+          })
+
+          wasActionExecuted mustBe true
+        }
+      }
+
+      describe("when a transaction is active") {
+        it("adds the action to the current transaction to be executed later") {
+          val hooks = new ThreadLocalJooqTransactionalHooks()
+
+          val transaction = new JooqTransaction()
+          hooks.setTransaction(transaction)
+
+          var wasActionExecuted = false
+          hooks.whenCommitted(new Runnable {
+            override def run(): Unit = {
+              wasActionExecuted = true
+            }
+          })
+
+          wasActionExecuted mustBe false
+
+          transaction.getCommitHooks.get(0).run()
+          wasActionExecuted mustBe true
+        }
+      }
+
+      describe("when multiple transactions are active on different threads") {
+        it("adds actions to their thread local transaction only") {
+          val hooks = new ThreadLocalJooqTransactionalHooks()
+
+          val transactionOne = new JooqTransaction()
+          val transactionTwo = new JooqTransaction()
+
+          var wasActionOneExecuted = false
+          val actionOne = new Runnable {
+            override def run(): Unit = {
+              wasActionOneExecuted = true
+            }
+          }
+
+          var wasActionTwoExecuted = false
+          val actionTwo = new Runnable {
+            override def run(): Unit = {
+              wasActionTwoExecuted = true
+            }
+          }
+
+          val threadOne = new Thread {
+            override def run(): Unit = {
+              hooks.setTransaction(transactionOne)
+              hooks.whenCommitted(actionOne)
+            }
+          }
+
+          val threadTwo = new Thread {
+            override def run(): Unit = {
+              hooks.setTransaction(transactionTwo)
+              hooks.whenCommitted(actionTwo)
+            }
+          }
+
+          wasActionOneExecuted mustBe false
+          wasActionTwoExecuted mustBe false
+
+          threadOne.start()
+          threadOne.join(5000)
+
+          transactionOne.getCommitHooks must have size 1
+          transactionOne.getCommitHooks.get(0).run()
+          wasActionOneExecuted mustBe true
+          wasActionTwoExecuted mustBe false
+
+          threadTwo.start()
+          threadTwo.join(5000)
+
+          transactionTwo.getCommitHooks must have size 1
+          transactionTwo.getCommitHooks.get(0).run()
+          wasActionTwoExecuted mustBe true
+        }
+      }
+    }
+
+    describe("#clearTransaction") {
+      it("removes any currently set transaction") {
+        val hooks = new ThreadLocalJooqTransactionalHooks()
+
+        val transaction = new JooqTransaction()
+        hooks.setTransaction(transaction)
+        hooks.clearTransaction()
+
+        var wasActionExecuted = false
+        hooks.whenCommitted(new Runnable {
+          override def run(): Unit = {
+            wasActionExecuted = true
+          }
+        })
+
+        transaction.getCommitHooks must have size 0
+        wasActionExecuted mustBe true
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,13 @@
 
   <properties>
     <beadledom.url>http://cerner.github.io/beadledom/${project.version}</beadledom.url>
-    <autovalue.version>1.6.2</autovalue.version>
+    <autovalue.version>1.6.5</autovalue.version>
     <java.version>1.8</java.version>
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.5</governator.version>
-    <jackson.version>2.9.8</jackson.version>
-    <resteasy.version>3.6.0.Final</resteasy.version>
+    <jackson.version>2.9.9</jackson.version>
+    <resteasy.version>3.6.3.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
     <swagger-core.version>1.3.12</swagger-core.version>
@@ -299,17 +299,17 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>26.0-jre</version>
+        <version>28.0-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.2.1</version>
+        <version>4.2.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.inject.extensions</groupId>
         <artifactId>guice-multibindings</artifactId>
-        <version>4.2.1</version>
+        <version>4.2.2</version>
       </dependency>
       <dependency>
         <groupId>com.netflix.governator</groupId>
@@ -492,7 +492,7 @@
       <dependency>
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
-        <version>3.11.3</version>
+        <version>3.11.11</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
@@ -722,7 +722,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.4</version>
         <configuration>
           <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
           <suppressionFile>dependency-check-suppressions.xml</suppressionFile>
@@ -995,7 +995,7 @@
         <version>${maven-project-info-reports-plugin.version}</version>
         <reportSets>
           <reportSet>
-            <reports />
+            <reports/>
           </reportSet>
         </reportSets>
       </plugin>


### PR DESCRIPTION
### What was changed? Why is this necessary?

Adds a new transaction hooks class that can be used to register actions during a Jooq transaction to be executed after the transaction is successfully committed.

### How was it tested?

* New unit tests
* Used in a service and manually tested some transactions.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
