### PR TITLE
Guice-based Beadledom clients will now use the correct time unit for time outs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 * JAX-RS providers with binding annotations will no longer be registered in the resteasy provider factory for the server.
+* Guice-based Beadledom clients will now use the correct time unit for time outs.
 
 ## 3.2.5 - 25 March 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 * JAX-RS providers with binding annotations will no longer be registered in the resteasy provider factory for the server.
-* Guice-based Beadledom clients will now use the correct time unit for time outs.
+* Guice-based Beadledom clients will now use the correct time unit for time-outs.
 
 ## 3.2.5 - 25 March 2019
 

--- a/client/beadledom-client-example/example-client/src/main/java/com/cerner/beadledom/client/example/client/ExampleOneClientModule.java
+++ b/client/beadledom-client-example/example-client/src/main/java/com/cerner/beadledom/client/example/client/ExampleOneClientModule.java
@@ -54,9 +54,9 @@ public class ExampleOneClientModule extends AbstractModule {
   BeadledomClientConfiguration provideClientConfig() {
     return BeadledomClientConfiguration.builder()
         .maxPooledPerRouteSize(60)
-        .socketTimeoutMillis(60)
-        .connectionTimeoutMillis(60)
-        .ttlMillis(60)
+        .socketTimeoutMillis(200)
+        .connectionTimeoutMillis(200)
+        .ttlMillis(200)
         .connectionPoolSize(60).build();
   }
 }

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderProvider.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderProvider.java
@@ -72,9 +72,9 @@ class BeadledomClientBuilderProvider implements Provider<BeadledomClientBuilder>
 
       clientBuilder.setConnectionPoolSize(config.connectionPoolSize());
       clientBuilder.setMaxPooledPerRouteSize(config.maxPooledPerRouteSize());
-      clientBuilder.setSocketTimeout(config.socketTimeoutMillis(), TimeUnit.SECONDS);
-      clientBuilder.setConnectionTimeout(config.connectionTimeoutMillis(), TimeUnit.SECONDS);
-      clientBuilder.setTtl(config.ttlMillis(), TimeUnit.SECONDS);
+      clientBuilder.setSocketTimeout(config.socketTimeoutMillis(), TimeUnit.MILLISECONDS);
+      clientBuilder.setConnectionTimeout(config.connectionTimeoutMillis(), TimeUnit.MILLISECONDS);
+      clientBuilder.setTtl(config.ttlMillis(), TimeUnit.MILLISECONDS);
 
       if (config.sslContext() != null) {
         clientBuilder.sslContext(config.sslContext());

--- a/client/beadledom-client-guice/src/test/scala/com/cerner/beadledom/client/BeadledomClientModuleSpec.scala
+++ b/client/beadledom-client-guice/src/test/scala/com/cerner/beadledom/client/BeadledomClientModuleSpec.scala
@@ -70,6 +70,8 @@ class BeadledomClientModuleSpec extends FunSpec with MustMatchers with BeforeAnd
               .builder()
               .connectionPoolSize(1)
               .connectionTimeoutMillis(2)
+              .socketTimeoutMillis(2)
+              .ttlMillis(2)
               .correlationIdName(correlationIdName)
               .build()
 
@@ -87,7 +89,9 @@ class BeadledomClientModuleSpec extends FunSpec with MustMatchers with BeforeAnd
       val config = clientBuilder.getBeadledomClientConfiguration
 
       config.connectionPoolSize mustBe 1
-      config.connectionTimeoutMillis mustBe 2 * 1000
+      config.connectionTimeoutMillis mustBe 2
+      config.socketTimeoutMillis mustBe 2
+      config.ttlMillis() mustBe 2
       config.correlationIdName mustBe correlationIdName
 
       classOf[BeadledomClient].isAssignableFrom(clientBuilder.build.getClass) mustBe true

--- a/client/beadledom-client-test/src/test/scala/com/cerner/beadledom/client/ClientServiceSpec.scala
+++ b/client/beadledom-client-test/src/test/scala/com/cerner/beadledom/client/ClientServiceSpec.scala
@@ -152,9 +152,9 @@ class ClientServiceSpec(contextRoot: String, servicePort: Int)
 
       beadledomClientConfiguration.connectionPoolSize() must be(60)
       beadledomClientConfiguration.maxPooledPerRouteSize() must be(60)
-      beadledomClientConfiguration.socketTimeoutMillis() must be(60)
-      beadledomClientConfiguration.connectionTimeoutMillis() must be(60)
-      beadledomClientConfiguration.ttlMillis() must be(60)
+      beadledomClientConfiguration.socketTimeoutMillis() must be(200)
+      beadledomClientConfiguration.connectionTimeoutMillis() must be(200)
+      beadledomClientConfiguration.ttlMillis() must be(200)
     }
   }
 }


### PR DESCRIPTION
### What was changed? Why is this necessary?

> Addresses issue https://github.com/cerner/beadledom/issues/144


### How was it tested?

> White box test and integration test was updated

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
