### PR TITLE
Update archetype to newer versions of dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Jooq transaction hooks for executing actions after a successful commit.
 
 ### Changed
+* Update archetype dependencies to match beadledom library
 * Switch to Keep a Changelog style for Changelog moving forward - https://keepachangelog.com/en/1.0.0/
 * Update maven archetype for project generation with new client recommendations.
 * Update client documentation to recommend using an abstracted resource pattern.
@@ -24,7 +25,7 @@
 
 ### Defects Corrected
 * Fixed exclusion of `jersey-media-multipart` from `swagger-jersey2-jaxrs`.
-* Jackson version uplift from 2.9.6 -> 2.9.8 because of vulnerabilities: 
+* Jackson version uplift from 2.9.6 -> 2.9.8 because of vulnerabilities:
   - CVE-2018-19360
   - CVE-2018-19362
   - CVE-2018-14720
@@ -41,7 +42,7 @@
 ## 3.2.2 - 4 December 2018
 
 ### Defects Corrected
-* [internal] Use the `-B` option on our `mvn site` command to reduce log length by eliminating progress dialogs from downloads. [More Info](https://stackoverflow.com/questions/21638697/disable-maven-download-progress-indication) 
+* [internal] Use the `-B` option on our `mvn site` command to reduce log length by eliminating progress dialogs from downloads. [More Info](https://stackoverflow.com/questions/21638697/disable-maven-download-progress-indication)
 
 ## 3.2.1 - 3 December 2018
 
@@ -70,13 +71,13 @@
 ## 3.0 - 3 August 2018
 
 ### Breaking Changes
-* Remove StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, AvroSwaggerGuiceModule, and 
-HealthModule modules from being installed by BeadledomModule. If the removed functionality is 
+* Remove StagemonitorModule, SwaggerModule, AvroJacksonGuiceModule, AvroSwaggerGuiceModule, and
+HealthModule modules from being installed by BeadledomModule. If the removed functionality is
 desired, install the removed modules in the consuming guice module.
 * Bump minimum Java version to 1.8 for all modules.
 * Upgrade to JAX-RS 2.1 with Resteasy 3.6.x
 * Change the HttpClient `ServiceUnavailableRetryStrategy` to only retry on 503 response codes.
-* The beadledom-swagger module was renamed to beadledom-swagger1 in preparation for support of 
+* The beadledom-swagger module was renamed to beadledom-swagger1 in preparation for support of
 swagger 2 and OpenAPI 3.
 
 ### Enhancements

--- a/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <java.jdk.version>1.8</java.jdk.version>
         <beadledom.version>\${beadledomVersion}</beadledom.version>
-        <guice.version>4.2.0</guice.version>
-        <jackson.version>2.9.7</jackson.version>
+        <guice.version>4.2.2</guice.version>
+        <jackson.version>2.9.9</jackson.version>
         <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -40,11 +40,16 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>15.0</version>
+                <version>28.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
+                <version>${guice.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.inject.extensions</groupId>
+                <artifactId>guice-multibindings</artifactId>
                 <version>${guice.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
### What was changed? Why is this necessary?

Bumped the version of dependencies in the archetype to later versions that are not vulnerable to security vulnerabilities. I also ran into an issue when I used the archetype in 3.2.5 with `NoSuchMethodError` around guava (`java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkArgument(ZLjava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)`) and after updating to a newer version (`java.lang.ClassNotFoundException: com.google.inject.multibindings.Multibinder`) since guice added multibinding extensions in a separate jar.

This also matches what beadledom libraries use

### How was it tested?

Create a sample project and updated the pom to get things working.

### How to test

- [x] `./mvnw clean install -U`
