### PR TITLE
Update ThreadLocalCommitHookExecutingTransactionListener to override TransactionListener#beginStart instead of TransactionListener#beginEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## [Unreleased]
+
+### Fixed
+* Update `ThreadLocalCommitHookExecutingTransactionListener` to override `TransactionListener#beginStart` instead of `TransactionListener#beginEnd`
+
 ## 3.3 - 8 August 2019
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ This file contains the list of developers who contributed to this repository
 * John Leacox [@johnlcox][john-leacox]
 * Jacob Williams [@brokensandals][jacob-williams]
 * Jonathan Wright [@jonnywri][jonathan-wright]
-* Nathan Schile [@shiftyeyes][nathan-schile]
+* Nathan Schile [@nathanschile][nathan-schile]
 * Alec Sears [@alecxvs][alec-sears]
 * Mayank Singh
 * Nimesh Subramanian [@nemo][nimesh-subramanian]

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListener.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListener.java
@@ -25,7 +25,7 @@ class ThreadLocalCommitHookExecutingTransactionListener extends DefaultTransacti
   }
 
   @Override
-  public void beginEnd(TransactionContext ctx) {
+  public void beginStart(TransactionContext ctx) {
     JooqTransaction transaction = new JooqTransaction();
 
     Deque<JooqTransaction> transactions = transactions();

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
@@ -68,12 +68,12 @@ class ThreadLocalCommitHookExecutingTransactionListenerSpec
         it("executes commit hooks in the order registered") {
           val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
 
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(rootActionOne)
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(nestedLevelOneActionOne)
 
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
           listener.commitEnd(context)
 
@@ -98,12 +98,12 @@ class ThreadLocalCommitHookExecutingTransactionListenerSpec
           it("only executes commit hooks for the non-rolled back connections") {
             val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
 
-            listener.beginEnd(context)
+            listener.beginStart(context)
             transactionalHooks.whenCommitted(rootActionOne)
-            listener.beginEnd(context)
+            listener.beginStart(context)
             transactionalHooks.whenCommitted(nestedLevelOneActionOne)
             transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
-            listener.beginEnd(context)
+            listener.beginStart(context)
             transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
 
             listener.rollbackEnd(context)
@@ -128,12 +128,12 @@ class ThreadLocalCommitHookExecutingTransactionListenerSpec
         it("does not execute commit hooks") {
           val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
 
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(rootActionOne)
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(nestedLevelOneActionOne)
           transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
 
           listener.commitEnd(context)
@@ -152,12 +152,12 @@ class ThreadLocalCommitHookExecutingTransactionListenerSpec
         it("does not execute commit hooks") {
           val listener = new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks)
 
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(rootActionOne)
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(nestedLevelOneActionOne)
           transactionalHooks.whenCommitted(nestedLevelOneActionTwo)
-          listener.beginEnd(context)
+          listener.beginStart(context)
           transactionalHooks.whenCommitted(nestedLevelTwoActionOne)
 
           listener.rollbackEnd(context)


### PR DESCRIPTION
### What was changed? Why is this necessary?

If there is a exception while beginning the [transaction](https://github.com/jOOQ/jOOQ/blob/version-3.11.12/jOOQ/src/main/java/org/jooq/impl/DefaultDSLContext.java#L516) then TransactionListener#beginEnd
is never called. When this happened, ThreadLocalCommitHookExecutingTransactionListener#rollbackEnd would throw a NoSuchElementException since TransactionListener#beginEnd was never called setting up transactionDeques object

### How was it tested?

Updated existing tests.


### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
