### PR TITLE
Deprecate custom PATCH annotation, fixes #151

### DIFF
--- a/jaxrs/src/main/java/com/cerner/beadledom/jaxrs/PATCH.java
+++ b/jaxrs/src/main/java/com/cerner/beadledom/jaxrs/PATCH.java
@@ -10,9 +10,12 @@ import javax.ws.rs.HttpMethod;
 /**
  * Indicates that the annotated method responds to HTTP PATCH requests.
  *
+ * @deprecated Use PATCH annotation from JAX-RS 2.1, https://jax-rs.github.io/apidocs/2.1/javax/ws/rs/PATCH.html
+ *
  * @author Eric Christensen
  * @since 2.5
  */
+@Deprecated
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @HttpMethod("PATCH")


### PR DESCRIPTION
### What was changed? Why is this necessary?
Fixes #151. Deprecated custom PATCH annotation recommending to use annotation from JAX-RS 2.1, https://jax-rs.github.io/apidocs/2.1/javax/ws/rs/PATCH.html


### How was it tested?

./mvnw clean install -U


### How to test

> This is bare minimum acceptable testing

- [x] `./mvnw clean install -U`
