### PR TITLE
Defaulted to not use SavePoints for JooqTransactional module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## 3.4 - 8 November 2019
+
+### Changed
+* Nested transactions via `@JooqTransactional` no longer use SavePoints. Technically this a non-passive behavioral change, but seems like the safer option and likely what is more in line with what is expected by users of `@JooqTransactional`.
+
 ### Deprecated
 * com.cerner.beadledom.jaxrs.PATCH has been deprecated. Use PATCH annotation from JAX-RS 2.1, https://jax-rs.github.io/apidocs/2.1/javax/ws/rs/PATCH.html instead.
 

--- a/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProviderImpl.java
+++ b/jooq/src/main/java/com/cerner/beadledom/jooq/DSLContextProviderImpl.java
@@ -29,7 +29,7 @@ class DSLContextProviderImpl implements DSLContextProvider, UnitOfWork {
     // all of the ThreadLocal semantics of Jooq and Transaction hooks for us.
     this.configuration = new DefaultConfiguration()
         .set(sqlDialect)
-        .set(new ThreadLocalTransactionProvider(new DataSourceConnectionProvider(dataSource)))
+        .set(new ThreadLocalTransactionProvider(new DataSourceConnectionProvider(dataSource), false))
         .set(new ThreadLocalCommitHookExecutingTransactionListener(transactionalHooks));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
       <dependency>
         <groupId>com.typesafe.play</groupId>
         <artifactId>play-json_${scala.binary.version}</artifactId>
-        <version>2.6.9</version>
+        <version>2.7.4</version>
       </dependency>
       <dependency>
         <groupId>com.wordnik</groupId>


### PR DESCRIPTION
### What was changed? Why is this necessary?

* Nested transactions via `@JooqTransactional` no longer use SavePoints. Technically this a non-passive behavioral change, but seems like the safer option and likely what is more in line with what is expected by users of `@JooqTransactional`.

### How was it tested?

Tested by integrating it into Java service consuming Beadledom and confirmed performance boost as well as successful database commits


### How to test

- [ ] `./mvnw clean install -U`
