### PR TITLE
Deprecate beadledom-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Guice. For more information on creating a service check out our [documentation](
 Beadledom is made up of the following components:
 
 * [avro](avro#beadledom-avro) - Additional Avro functionality required for services.
-* [client](client#beadledom-client) - HTTP client for communicating with the JAX-RS web services.
+* [client](client#beadledom-client) - *Deprecated.* HTTP client for communicating with the JAX-RS web services.
 * [common](common#beadledom-common) - Common utilities.
 * [Configuration](configuration#beadledom-configuration) - Centralized API to access the aggregated configurations from different sources.
 * [core](core#beadledom-core) - Core Guice module that pulls in all the other recommended Beadledom modules.

--- a/client/README.rst
+++ b/client/README.rst
@@ -1,4 +1,6 @@
 .. _beadledom-client:
 
+Deprecated since 4.0, use `Retrofit <https://github.com/square/retrofit>`_ instead.
+
 `Check out our docs for more information <http://cerner.github.io/beadledom>`_
 

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderProvider.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderProvider.java
@@ -24,7 +24,9 @@ import javax.ws.rs.core.Feature;
  * @author Sundeep Paruvu
  * @author Nimesh Subramanian
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class BeadledomClientBuilderProvider implements Provider<BeadledomClientBuilder> {
   private final Class<? extends Annotation> clientBindingAnnotation;
   private DynamicBindingProvider<BeadledomClientBuilderFactory> clientBuilderFactoryProvider;

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientLifecycleHook.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientLifecycleHook.java
@@ -14,7 +14,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author John Leacox
  * @since 2.0
+ * @deprecated
  */
+@Deprecated
 class BeadledomClientLifecycleHook {
   private static final Logger logger = LoggerFactory.getLogger(BeadledomClientLifecycleHook.class);
 

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientLifecycleHook.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientLifecycleHook.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author John Leacox
  * @since 2.0
- * @deprecated
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
 @Deprecated
 class BeadledomClientLifecycleHook {

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientLifecycleHookProvider.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientLifecycleHookProvider.java
@@ -12,7 +12,9 @@ import javax.inject.Provider;
  * A Guice provider for {@link ResteasyClientLifecycleHook}.
  *
  * @author John Leacox
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class BeadledomClientLifecycleHookProvider implements Provider<BeadledomClientLifecycleHook> {
   private final Class<? extends Annotation> annotation;
 

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientModule.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientModule.java
@@ -44,7 +44,9 @@ import java.lang.annotation.Annotation;
  * @author John Leacox
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class BeadledomClientModule extends AbstractModule {
   private final Class<? extends Annotation> clientBindingAnnotation;
 

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientPrivateModule.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientPrivateModule.java
@@ -54,7 +54,9 @@ import java.lang.annotation.Annotation;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class BeadledomClientPrivateModule extends AnnotatedModule {
 
   BeadledomClientPrivateModule(Class<? extends Annotation> clientBindingAnnotation) {

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientProvider.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/BeadledomClientProvider.java
@@ -12,7 +12,9 @@ import javax.inject.Provider;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class BeadledomClientProvider implements Provider<BeadledomClient> {
   private final Class<? extends Annotation> clientBindingAnnotation;
   private DynamicBindingProvider<BeadledomClientBuilder> clientBuilderProvider;

--- a/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/CorrelationIdClientHeader.java
+++ b/client/beadledom-client-guice/src/main/java/com/cerner/beadledom/client/CorrelationIdClientHeader.java
@@ -15,7 +15,9 @@ import java.lang.annotation.Target;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 @BindingAnnotation
 @Target({FIELD, PARAMETER, METHOD})
 @Retention(RUNTIME)

--- a/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedJacksonModule.java
+++ b/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedJacksonModule.java
@@ -88,7 +88,9 @@ import java.lang.annotation.Annotation;
  * @author Sundeep Paruvu
  * @since 2.2
  * @see JacksonModule
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class AnnotatedJacksonModule extends AbstractModule {
 
   private final Class<? extends Annotation> clientBindingAnnotation;

--- a/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedJacksonPrivateModule.java
+++ b/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedJacksonPrivateModule.java
@@ -41,7 +41,9 @@ import java.util.Set;
  *
  * @author Sundeep Paruvu
  * @since 2.2
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class AnnotatedJacksonPrivateModule extends AnnotatedModule {
 
   protected AnnotatedJacksonPrivateModule(

--- a/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedObjectMapperProvider.java
+++ b/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedObjectMapperProvider.java
@@ -26,7 +26,9 @@ import java.util.Set;
  *
  * @author Sundeep Paruvu
  * @since 2.2
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class AnnotatedObjectMapperProvider implements Provider<ObjectMapper> {
 
   private final Class<? extends Annotation> clientBindingAnnotation;

--- a/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/JacksonJsonGuiceProvider.java
+++ b/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/JacksonJsonGuiceProvider.java
@@ -16,7 +16,9 @@ import javax.inject.Provider;
  * @author Sundeep Paruvu
  * @author Nimesh Subramanian
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class JacksonJsonGuiceProvider implements Provider<JacksonJsonProvider> {
   private ObjectMapper objectMapper;
   private final Class<? extends Annotation> clientBindingAnnotation;

--- a/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/ObjectMapperClientFeatureModule.java
+++ b/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/ObjectMapperClientFeatureModule.java
@@ -22,7 +22,9 @@ import java.lang.annotation.Annotation;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class ObjectMapperClientFeatureModule extends AbstractModule {
   private final Class<? extends Annotation> clientBindingAnnotation;
 

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClient.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClient.java
@@ -13,7 +13,9 @@ import javax.ws.rs.core.UriBuilder;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public abstract class BeadledomClient implements Client {
 
   protected BeadledomClient() {}

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilder.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilder.java
@@ -20,7 +20,9 @@ import javax.ws.rs.core.UriBuilder;
  * @author John Leacox
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public abstract class BeadledomClientBuilder extends ClientBuilder {
   /**
    * Allows custom implementations to extend the {@code BeadledomJaxrsClientBuilder} class.

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderFactory.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientBuilderFactory.java
@@ -9,7 +9,9 @@ package com.cerner.beadledom.client;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public interface BeadledomClientBuilderFactory {
 
   /**

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientConfiguration.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomClientConfiguration.java
@@ -8,8 +8,10 @@ import javax.net.ssl.SSLContext;
 
 /**
  * Resteasy client builder to use with guice.
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
 @AutoValue
+@Deprecated
 public abstract class BeadledomClientConfiguration {
   private static final int DEFAULT_CONNECTION_POOL_SIZE = 200;
   private static final int DEFAULT_MAX_POOLED_PER_ROUTE = 100;

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomWebTarget.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/BeadledomWebTarget.java
@@ -8,7 +8,9 @@ import javax.ws.rs.client.WebTarget;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public abstract class BeadledomWebTarget implements WebTarget {
   protected BeadledomWebTarget() {
   }

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/CorrelationIdContext.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/CorrelationIdContext.java
@@ -10,7 +10,9 @@ import javax.annotation.Nullable;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public interface CorrelationIdContext {
   /**
    * The default header name for the correlationId.

--- a/client/beadledom-client/src/main/java/com/cerner/beadledom/client/CorrelationIdFilter.java
+++ b/client/beadledom-client/src/main/java/com/cerner/beadledom/client/CorrelationIdFilter.java
@@ -19,7 +19,9 @@ import javax.ws.rs.ext.Provider;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 @Provider
 @Priority(Priorities.HEADER_DECORATOR)
 public class CorrelationIdFilter implements ClientRequestFilter {

--- a/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericClientProxy.java
+++ b/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericClientProxy.java
@@ -17,7 +17,9 @@ import javax.ws.rs.core.Response;
  *
  * @author John Leacox
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class GenericClientProxy implements InvocationHandler {
   private final Object underlying;
 

--- a/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericResponseResourceProxyFactory.java
+++ b/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericResponseResourceProxyFactory.java
@@ -9,7 +9,9 @@ import java.lang.reflect.Proxy;
  *
  * @author John Leacox
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class GenericResponseResourceProxyFactory implements ResourceProxyFactory {
   private final GenericResponseResourceTransformer transformer =
       new GenericResponseResourceTransformer();

--- a/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericResponseResourceTransformer.java
+++ b/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/GenericResponseResourceTransformer.java
@@ -28,7 +28,9 @@ import javax.ws.rs.core.Response;
  *
  * @author John Leacox
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class GenericResponseResourceTransformer {
   private static final String PROXY_PREFIX = "JaxRsGenericResponseProxy_";
 

--- a/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/ResourceProxyFactory.java
+++ b/client/beadledom-jaxrs-clientproxy/src/main/java/com/cerner/beadledom/client/proxy/ResourceProxyFactory.java
@@ -5,7 +5,9 @@ package com.cerner.beadledom.client.proxy;
  *
  * @author John Leacox
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public interface ResourceProxyFactory {
   /**
    * Creates a proxied instance of the given JAX-RS resource class.

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClient.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClient.java
@@ -16,7 +16,9 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class BeadledomResteasyClient extends BeadledomClient {
   private final ResteasyClient client;
 

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilder.java
@@ -43,6 +43,7 @@ import org.jboss.resteasy.client.jaxrs.engines.ApacheHttpClient43Engine;
  * @author John Leacox
  * @author Sundeep Paruvu
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
 public class BeadledomResteasyClientBuilder extends BeadledomClientBuilder {
   private static final int DEFAULT_RETRY_INTERVAL_MILLIS = 1000;

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyWebTarget.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/BeadledomResteasyWebTarget.java
@@ -15,7 +15,9 @@ import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class BeadledomResteasyWebTarget extends BeadledomWebTarget {
   private final ResteasyWebTarget webTarget;
 

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ResteasyClientBuilderFactory.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ResteasyClientBuilderFactory.java
@@ -7,7 +7,9 @@ import com.cerner.beadledom.client.BeadledomClientBuilderFactory;
  *
  * @author Sundeep Paruvu
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class ResteasyClientBuilderFactory implements BeadledomClientBuilderFactory {
 
   @Override

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ResteasyCorrelationIdContext.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ResteasyCorrelationIdContext.java
@@ -13,7 +13,9 @@ import org.slf4j.MDC;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class ResteasyCorrelationIdContext implements CorrelationIdContext {
   private final String headerName;
   private final String mdcName;

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ResteasyResourceProxyFactory.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ResteasyResourceProxyFactory.java
@@ -9,7 +9,9 @@ import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
  *
  * @author John Leacox
  * @since 2.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 class ResteasyResourceProxyFactory implements ResourceProxyFactory {
   private final ResteasyWebTarget webTarget;
 

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategy.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategy.java
@@ -13,7 +13,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class DefaultServiceUnavailableRetryStrategy
     implements ServiceUnavailableRetryStrategy {
   private static final Logger logger =

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapter.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapter.java
@@ -14,7 +14,9 @@ import org.apache.http.conn.ssl.X509HostnameVerifier;
  *
  * @author John Leacox
  * @since 1.0
+ * @deprecated As of 4.0, use Retrofit (https://github.com/square/retrofit) instead.
  */
+@Deprecated
 public class X509HostnameVerifierAdapter implements X509HostnameVerifier {
   private final HostnameVerifier verifier;
 

--- a/docs/source/manual/beadledom_client.rst
+++ b/docs/source/manual/beadledom_client.rst
@@ -3,6 +3,8 @@
 beadledom-client
 ================
 
+Deprecated since 4.0, use `Retrofit <https://github.com/square/retrofit>`_ instead.
+
 Beadledom Client is a JAX-RS 2.0 based HTTP Client for Java. It provides a wrapper around the JAX-RS 2.0 client API along with some additional functionality including a `CorrelationIdFilter <https://github.com/cerner/beadledom/blob/master/client/beadledom-client/src/main/java/com/cerner/beadledom/client/CorrelationIdFilter.java>`_ that will set a correlation id header on all client calls.
 
 Beadledom Client is designed to provide a common way of writing Java HTTP clients. It internally wraps another implementation of HTTP Client to execute the HTTP requests. Similarly to, and to stay consistent with, `Beadledom <https://github.com/cerner/beadledom>`_ the JAX-RS 2.0 client API provides a default implementation by wrapping the Resteasy Client for creating HTTP clients.

--- a/docs/source/releases/Beadledom40.rst
+++ b/docs/source/releases/Beadledom40.rst
@@ -28,3 +28,5 @@ on beadledom-swagger1 to beadledom-swagger2. The user guide for beadledom-swagge
 
 The beadledom-stagemonitor module was removed. This will require updating your poms that have a dependency
 on beadledom-stagemonitor.
+
+The beadledom-client module has been deprecated. Use Square's `Retrofit <https://github.com/square/retrofit>`_ instead.


### PR DESCRIPTION
### What was changed? Why is this necessary?

Marked `beadledom-client` module as deprecated in favor of Retrofit. Added notes indicating such to the docs of beadledom-client, the 4.0 migration guide, and the readme.

Closes #160 