### PR TITLE
Upgrade to Scala 2.12 and scalatest 3.1

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  RenameDeprecatedPackage
+]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,3 @@
 rules = [
-  RenameDeprecatedPackage
+  RewriteDeprecatedNames
 ]

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,0 @@
-rules = [
-  RewriteDeprecatedNames
-]

--- a/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
@@ -13,8 +13,8 @@
         <beadledom.version>\${beadledomVersion}</beadledom.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.10.0</jackson.version>
-        <scala.version>2.13.1</scala.version>
-        <scala.binary.version>2.13</scala.binary.version>
+        <scala.version>2.12.11</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
 

--- a/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/simple-service/src/main/resources/archetype-resources/pom.xml
@@ -12,9 +12,9 @@
         <java.jdk.version>1.8</java.jdk.version>
         <beadledom.version>\${beadledomVersion}</beadledom.version>
         <guice.version>4.2.2</guice.version>
-        <jackson.version>2.9.9</jackson.version>
-        <scala.version>2.11.8</scala.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <jackson.version>2.10.0</jackson.version>
+        <scala.version>2.13.1</scala.version>
+        <scala.binary.version>2.13</scala.binary.version>
         <slf4j.version>1.7.25</slf4j.version>
     </properties>
 

--- a/avro/jackson/src/test/scala/com/cerner/beadledom/avro/AvroJacksonGuiceModuleSpec.scala
+++ b/avro/jackson/src/test/scala/com/cerner/beadledom/avro/AvroJacksonGuiceModuleSpec.scala
@@ -5,14 +5,15 @@ import com.fasterxml.jackson.databind.{Module, ObjectMapper}
 import com.google.inject._
 import com.google.inject.multibindings.ProvidesIntoSet
 import java.util.Properties
-import org.scalatest.{FunSpec, Matchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Spec tests for {@link AvroJacksonGuiceModule}.
  */
-class AvroJacksonGuiceModuleSpec extends FunSpec with Matchers with MockitoSugar {
+class AvroJacksonGuiceModuleSpec extends AnyFunSpec with Matchers with MockitoSugar {
   val injector = Guice.createInjector(new AbstractModule() {
     override def configure(): Unit = {
       val buildInfo = BuildInfo.builder()

--- a/avro/jackson/src/test/scala/com/cerner/beadledom/avro/AvroJacksonGuiceModuleSpec.scala
+++ b/avro/jackson/src/test/scala/com/cerner/beadledom/avro/AvroJacksonGuiceModuleSpec.scala
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.{Module, ObjectMapper}
 import com.google.inject._
 import com.google.inject.multibindings.ProvidesIntoSet
 import java.util.Properties
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec tests for {@link AvroJacksonGuiceModule}.

--- a/avro/swagger/src/test/scala/com/cerner/beadledom/avro/SwaggerAvroModelConverterSpec.scala
+++ b/avro/swagger/src/test/scala/com/cerner/beadledom/avro/SwaggerAvroModelConverterSpec.scala
@@ -9,15 +9,17 @@ import io.swagger.converter.ModelConverters
 import io.swagger.jaxrs.listing.SwaggerSerializers
 import io.swagger.models.Swagger
 import javax.ws.rs.core.MediaType
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.collection.JavaConverters
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Spec tests for {@link SwaggerAvroModelConverter}.
  */
 class SwaggerAvroModelConverterSpec
-  extends FunSpec with Matchers with JsonMatchers with BeforeAndAfterAll {
+  extends AnyFunSpec with Matchers with JsonMatchers with BeforeAndAfterAll {
   val converter = new SwaggerAvroModelConverter
 
   override def beforeAll = {

--- a/client/beadledom-client-guice/src/test/scala/com/cerner/beadledom/client/BeadledomClientLifecycleHookSpec.scala
+++ b/client/beadledom-client-guice/src/test/scala/com/cerner/beadledom/client/BeadledomClientLifecycleHookSpec.scala
@@ -2,14 +2,15 @@ package com.cerner.beadledom.client
 
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Unit tests for ResteasyClientLifecycleHook.
   *
   * @author John Leacox
   */
-class BeadledomClientLifecycleHookSpec extends FunSpec with Matchers {
+class BeadledomClientLifecycleHookSpec extends AnyFunSpec with Matchers {
   describe("BeadledomClientLifecycleHook") {
     it("closes the BeadledomClient when @PreDestroy is executed") {
       val client = mock(classOf[BeadledomClient])

--- a/client/beadledom-client-guice/src/test/scala/com/cerner/beadledom/client/BeadledomClientModuleSpec.scala
+++ b/client/beadledom-client-guice/src/test/scala/com/cerner/beadledom/client/BeadledomClientModuleSpec.scala
@@ -2,12 +2,14 @@ package com.cerner.beadledom.client
 
 import com.google.inject._
 import javax.ws.rs.ext
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * @author John Leacox
   */
-class BeadledomClientModuleSpec extends FunSpec with MustMatchers with BeforeAndAfter {
+class BeadledomClientModuleSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
 
   def getTestBindingInjector(modules: List[Module]): Injector = {
     val module = new AbstractModule {

--- a/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/AnnotatedJacksonModuleSpec.scala
+++ b/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/AnnotatedJacksonModuleSpec.scala
@@ -4,15 +4,17 @@ import com.cerner.beadledom.client.jackson.test.annotations.TestBindingAnnotatio
 import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, ObjectMapper, SerializationFeature}
 import com.google.inject.{Guice, Injector, Key}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Specs for [[AnnotatedJacksonModule]].
  */
 class AnnotatedJacksonModuleSpec
-    extends FunSpec with BeforeAndAfter with Matchers with MockitoSugar {
+    extends AnyFunSpec with BeforeAndAfter with Matchers with MockitoSugar {
   var injector: Injector = _
   var mapper: ObjectMapper = _
   before {

--- a/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/AnnotatedJacksonModuleSpec.scala
+++ b/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/AnnotatedJacksonModuleSpec.scala
@@ -4,9 +4,9 @@ import com.cerner.beadledom.client.jackson.test.annotations.TestBindingAnnotatio
 import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, ObjectMapper, SerializationFeature}
 import com.google.inject.{Guice, Injector, Key}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Specs for [[AnnotatedJacksonModule]].

--- a/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/feature/ObjectMapperClientFeatureModuleSpec.scala
+++ b/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/feature/ObjectMapperClientFeatureModuleSpec.scala
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 import com.google.inject.multibindings.ProvidesIntoSet
 import com.google.inject.{AbstractModule, Guice, Key, Module}
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Unit tests for ObjectMapperClientFeatureModule.

--- a/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/feature/ObjectMapperClientFeatureModuleSpec.scala
+++ b/client/beadledom-client-jackson/src/test/scala/com/cerner/beadledom/client/jackson/feature/ObjectMapperClientFeatureModuleSpec.scala
@@ -9,6 +9,8 @@ import com.google.inject.multibindings.ProvidesIntoSet
 import com.google.inject.{AbstractModule, Guice, Key, Module}
 import org.scalatest._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Unit tests for ObjectMapperClientFeatureModule.
@@ -16,7 +18,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class ObjectMapperClientFeatureModuleSpec
-    extends FunSpec with BeforeAndAfter with Matchers with MockitoSugar {
+    extends AnyFunSpec with BeforeAndAfter with Matchers with MockitoSugar {
   var testModule: Module = _
 
   before {

--- a/client/beadledom-client-test/src/test/scala/com/cerner/beadledom/client/ClientServiceSpec.scala
+++ b/client/beadledom-client-test/src/test/scala/com/cerner/beadledom/client/ClientServiceSpec.scala
@@ -6,14 +6,16 @@ import com.cerner.beadledom.client.example.PaginatedClientResource
 import com.cerner.beadledom.jaxrs.GenericResponse
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
 import com.google.inject._
-import org.scalatest.{BeforeAndAfter, DoNotDiscover, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, DoNotDiscover}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Specs to test the Clients of a service.
  */
 @DoNotDiscover
 class ClientServiceSpec(contextRoot: String, servicePort: Int)
-    extends FunSpec with MustMatchers with BeforeAndAfter {
+    extends AnyFunSpec with Matchers with BeforeAndAfter {
   val baseUri = s"http://localhost:$servicePort$contextRoot"
 
   def getInjector(modules: List[Module]): Injector = {

--- a/client/beadledom-client-test/src/test/scala/com/cerner/beadledom/client/ServiceBackedSpecSuite.scala
+++ b/client/beadledom-client-test/src/test/scala/com/cerner/beadledom/client/ServiceBackedSpecSuite.scala
@@ -6,16 +6,17 @@ import org.apache.catalina.Globals
 import org.apache.catalina.startup.Tomcat
 import org.apache.commons.io.FileUtils
 import org.apache.naming.resources.VirtualDirContext
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Suite}
+import org.scalatest.{BeforeAndAfterAll, Suite}
 
 import java.io.File
 
 import scala.collection.immutable.IndexedSeq
+import org.scalatest.funspec.AnyFunSpec
 
 /**
   * Spec Suite to test the Clients of a service.
   */
-class ServiceBackedSpecSuite extends FunSpec with BeforeAndAfterAll {
+class ServiceBackedSpecSuite extends AnyFunSpec with BeforeAndAfterAll {
   val tomcat = new Tomcat
   val tomcatPort = Integer.parseInt(System.getProperty("tomcat.http.port", "9091"))
   val contextRoot = "/faux-service"

--- a/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/BeadledomClientBuilderSpec.scala
+++ b/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/BeadledomClientBuilderSpec.scala
@@ -4,12 +4,12 @@ import javax.ws.rs.core.Configuration
 
 import com.cerner.beadledom.client.BeadledomClientBuilder
 import org.mockito.Mockito
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
 /**
  * @author John Leacox
  */
-class BeadledomClientBuilderSpec extends FunSpec {
+class BeadledomClientBuilderSpec extends AnyFunSpec {
   describe("BeadledomClientBuilder") {
     describe("#create") {
       it("throws an IllegalStateException if an implementation is not found through SPI") {

--- a/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/BeadledomClientConfigurationSpec.scala
+++ b/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/BeadledomClientConfigurationSpec.scala
@@ -1,8 +1,10 @@
 package com.cerner.beadledom.client
 
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class BeadledomClientConfigurationSpec extends FunSpec with Matchers with BeforeAndAfter{
+class BeadledomClientConfigurationSpec extends AnyFunSpec with Matchers with BeforeAndAfter{
 
   describe("BeadledomClientConfiguration") {
 

--- a/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/CorrelationIdFilterBehaviors.scala
+++ b/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/CorrelationIdFilterBehaviors.scala
@@ -3,13 +3,12 @@ package com.cerner.beadledom.client.jaxrs
 import java.util.UUID
 import javax.ws.rs.client.ClientRequestContext
 import javax.ws.rs.core.MultivaluedHashMap
-
 import com.cerner.beadledom.client.CorrelationIdFilter
 import org.mockito.Mockito
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.{BeMatcher, MatchResult}
-import org.scalatest.{FunSpec, Matchers}
-
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Testing Behaviors for the {@link CorrelationIdFilter}
@@ -17,7 +16,7 @@ import scala.util.Try
   * @author John Leacox
   */
 trait CorrelationIdFilterBehaviors extends Matchers {
-  this: FunSpec =>
+  this: AnyFunSpec =>
 
   val aUUID =
     BeMatcher { (left: Any) =>

--- a/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/CorrelationIdFilterSpec.scala
+++ b/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/CorrelationIdFilterSpec.scala
@@ -2,7 +2,7 @@ package com.cerner.beadledom.client.jaxrs
 
 import com.cerner.beadledom.client.CorrelationIdFilter
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Spec for the {@link CorrelationIdFilter}

--- a/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/CorrelationIdFilterSpec.scala
+++ b/client/beadledom-client/src/test/scala/com/cerner/beadledom/client/CorrelationIdFilterSpec.scala
@@ -3,13 +3,15 @@ package com.cerner.beadledom.client.jaxrs
 import com.cerner.beadledom.client.CorrelationIdFilter
 import org.scalatest._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Spec for the {@link CorrelationIdFilter}
   *
   * @author John Leacox
   */
-class CorrelationIdFilterSpec extends FunSpec with BeforeAndAfter with Matchers
+class CorrelationIdFilterSpec extends AnyFunSpec with BeforeAndAfter with Matchers
     with MockitoSugar with CorrelationIdFilterBehaviors {
   val defaultHeaderName = "Correlation-Id"
 

--- a/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericClientProxySpec.scala
+++ b/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericClientProxySpec.scala
@@ -3,10 +3,10 @@ package com.cerner.beadledom.client.proxy
 import com.cerner.beadledom.jaxrs.GenericResponse
 
 import org.scalatest.{FunSpec, MustMatchers}
-import org.scalatest.mockito.MockitoSugar
 import org.mockito.Mockito._
 
 import javax.ws.rs.core.{GenericType, Response}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * @author John Leacox

--- a/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericClientProxySpec.scala
+++ b/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericClientProxySpec.scala
@@ -2,16 +2,17 @@ package com.cerner.beadledom.client.proxy
 
 import com.cerner.beadledom.jaxrs.GenericResponse
 
-import org.scalatest.{FunSpec, MustMatchers}
 import org.mockito.Mockito._
 
 import javax.ws.rs.core.{GenericType, Response}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * @author John Leacox
   */
-class GenericClientProxySpec extends FunSpec with MustMatchers with MockitoSugar {
+class GenericClientProxySpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("GenericClientProxy") {
     describe("#invoke") {
       it("delegates to underlying transformed resource and wraps the result in a GenericResponse") {

--- a/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericResponseResourceProxyFactorySpec.scala
+++ b/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericResponseResourceProxyFactorySpec.scala
@@ -4,12 +4,12 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 
 import javax.ws.rs.core.Response
 
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * @author John Leacox

--- a/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericResponseResourceProxyFactorySpec.scala
+++ b/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericResponseResourceProxyFactorySpec.scala
@@ -4,17 +4,18 @@ import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{FunSpec, MustMatchers}
 
 import javax.ws.rs.core.Response
 
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * @author John Leacox
   */
-class GenericResponseResourceProxyFactorySpec extends FunSpec with MustMatchers with MockitoSugar {
+class GenericResponseResourceProxyFactorySpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("GenericResponseResourceProxyFactory") {
     describe("#proxy") {
       it("it creates a delegate proxy with GenericResponse returns type replaced with Response") {

--- a/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericResponseResourceTransformerSpec.scala
+++ b/client/beadledom-jaxrs-clientproxy/src/test/scala/com/cerner/beadledom/client/proxy/GenericResponseResourceTransformerSpec.scala
@@ -1,13 +1,14 @@
 package com.cerner.beadledom.client.proxy
 
-import org.scalatest.{FunSpec, MustMatchers}
 
 import javax.ws.rs.core.Response
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * @author John Leacox
   */
-class GenericResponseResourceTransformerSpec extends FunSpec with MustMatchers {
+class GenericResponseResourceTransformerSpec extends AnyFunSpec with Matchers {
   describe("GenericResponseResourceTransformer") {
     describe("#transform") {
       it ("transformers methods returning GenericResponse to Response") {

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilderSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/BeadledomResteasyClientBuilderSpec.scala
@@ -1,14 +1,16 @@
 package com.cerner.beadledom.client.resteasy
 
 import com.cerner.beadledom.client.BeadledomClientBuilder
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 
 import scala.language.postfixOps
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author John Leacox
   */
-class BeadledomResteasyClientBuilderSpec extends FunSpec with Matchers with BeforeAndAfter {
+class BeadledomResteasyClientBuilderSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   describe("BeadledomResteasyClientBuilder") {
     describe("ServiceLoader") {
       it("loads the resteasy builder implementation") {

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/DefaultClientHttpEngineSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/DefaultClientHttpEngineSpec.scala
@@ -4,15 +4,17 @@ import com.cerner.beadledom.client.TestResource
 import java.util.concurrent.atomic.AtomicLong
 import javax.ws.rs.NotFoundException
 import javax.ws.rs.client.{Client, Entity}
-import org.scalatest.{BeforeAndAfter, DoNotDiscover, FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, DoNotDiscover}
 import org.slf4j.{Logger, LoggerFactory}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author John Leacox
  */
 @DoNotDiscover
 class DefaultClientHttpEngineSpec(contextRoot: String, servicePort: Int)
-    extends FunSpec with Matchers with BeforeAndAfter {
+    extends AnyFunSpec with Matchers with BeforeAndAfter {
   val logger: Logger = LoggerFactory.getLogger(classOf[DefaultClientHttpEngineSpec])
 
   val threadCount = 7

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ResteasyClientBuilderFactorySpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ResteasyClientBuilderFactorySpec.scala
@@ -1,11 +1,12 @@
 package com.cerner.beadledom.client.resteasy
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Specs for ResteasyClientBuilderFactory.
   */
-class ResteasyClientBuilderFactorySpec extends FunSpec with MustMatchers {
+class ResteasyClientBuilderFactorySpec extends AnyFunSpec with Matchers {
 
   val factory = new ResteasyClientBuilderFactory()
 

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ResteasyClientSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ResteasyClientSpec.scala
@@ -9,13 +9,15 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 
 import org.scalatest._
 import org.slf4j.MDC
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * @author John Leacox
   */
 @DoNotDiscover
 class ResteasyClientSpec(contextRoot: String, servicePort: Int)
-    extends FunSpec with MustMatchers with BeforeAndAfter {
+    extends AnyFunSpec with Matchers with BeforeAndAfter {
   after {
     MDC.clear()
   }

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ServiceBackedSpecSuite.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ServiceBackedSpecSuite.scala
@@ -6,13 +6,14 @@ import org.apache.catalina.Globals
 import org.apache.catalina.startup.Tomcat
 import org.apache.commons.io.FileUtils
 import org.apache.naming.resources.VirtualDirContext
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Suite}
+import org.scalatest.{BeforeAndAfterAll, Suite}
 import scala.collection.immutable.IndexedSeq
+import org.scalatest.funspec.AnyFunSpec
 
 /**
  * @author John Leacox
  */
-class ServiceBackedSpecSuite extends FunSpec with BeforeAndAfterAll {
+class ServiceBackedSpecSuite extends AnyFunSpec with BeforeAndAfterAll {
   val tomcat = new Tomcat
   val tomcatPort = Integer.parseInt(System.getProperty("tomcat.http.port", "9091"))
   val contextRoot = "/faux-service"

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
@@ -4,14 +4,15 @@ import org.apache.http.client.ServiceUnavailableRetryStrategy
 import org.apache.http.client.protocol.HttpClientContext
 import org.apache.http.{HttpRequest, HttpResponse, RequestLine, StatusLine}
 import org.mockito.Mockito
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author John Leacox
  */
 class DefaultServiceUnavailableRetryStrategySpec
-    extends FunSpec with Matchers with MockitoSugar with RetryRequestBehaviors {
+    extends AnyFunSpec with Matchers with MockitoSugar with RetryRequestBehaviors {
   describe("DefaultServiceUnavailableRetryStrategySpec") {
     describe("#getRetryInterval") {
       it("returns the retry interval given to the constructor") {
@@ -76,7 +77,7 @@ class DefaultServiceUnavailableRetryStrategySpec
 }
 
 trait RetryRequestBehaviors extends Matchers with MockitoSugar {
-  this: FunSpec =>
+  this: AnyFunSpec =>
 
   def retryableRequest(retryStrategy: ServiceUnavailableRetryStrategy, statusCode: Int,
       executionCount: Int): Unit = {

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/DefaultServiceUnavailableRetryStrategySpec.scala
@@ -4,8 +4,8 @@ import org.apache.http.client.ServiceUnavailableRetryStrategy
 import org.apache.http.client.protocol.HttpClientContext
 import org.apache.http.{HttpRequest, HttpResponse, RequestLine, StatusLine}
 import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * @author John Leacox

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapterSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapterSpec.scala
@@ -4,14 +4,16 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.{HostnameVerifier, SSLException, SSLSession, SSLSocket}
 import org.apache.http.conn.ssl.X509HostnameVerifier
 import org.mockito.Mockito
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author John Leacox
  */
 class X509HostnameVerifierAdapterSpec
-    extends FunSpec with Matchers with BeforeAndAfter with MockitoSugar {
+    extends AnyFunSpec with Matchers with BeforeAndAfter with MockitoSugar {
   describe("X509HostnameVerifierAdapter") {
     describe("#adapt") {
       it("throws a NullPointerException if the adaptee is null") {

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapterSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/http/X509HostnameVerifierAdapterSpec.scala
@@ -4,8 +4,8 @@ import java.security.cert.X509Certificate
 import javax.net.ssl.{HostnameVerifier, SSLException, SSLSession, SSLSocket}
 import org.apache.http.conn.ssl.X509HostnameVerifier
 import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * @author John Leacox

--- a/common/src/test/scala/com/cerner/beadledom/metadata/BuildInfoSpec.scala
+++ b/common/src/test/scala/com/cerner/beadledom/metadata/BuildInfoSpec.scala
@@ -1,12 +1,13 @@
 package com.cerner.beadledom.metadata
 
 import java.util.Properties
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Spec tests for {@link BuildInfo}.
  */
-class BuildInfoSpec extends FunSpec with Matchers {
+class BuildInfoSpec extends AnyFunSpec with Matchers {
   val properties = new Properties()
   properties.setProperty("git.commit.id", "abcdef")
   properties.setProperty("project.artifactId", "blub-factory")

--- a/common/src/test/scala/com/cerner/beadledom/metadata/ServiceMetadataSpec.scala
+++ b/common/src/test/scala/com/cerner/beadledom/metadata/ServiceMetadataSpec.scala
@@ -2,13 +2,14 @@ package com.cerner.beadledom.metadata
 
 import java.net.InetAddress
 import java.time.Instant
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Spec tests for {@link ServiceMetadata}.
  */
-class ServiceMetadataSpec extends FunSpec with Matchers with MockitoSugar {
+class ServiceMetadataSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("ServiceMetadata") {
     describe(".create") {
       it("builds a default object correctly") {

--- a/common/src/test/scala/com/cerner/beadledom/metadata/ServiceMetadataSpec.scala
+++ b/common/src/test/scala/com/cerner/beadledom/metadata/ServiceMetadataSpec.scala
@@ -2,8 +2,8 @@ package com.cerner.beadledom.metadata
 
 import java.net.InetAddress
 import java.time.Instant
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec tests for {@link ServiceMetadata}.

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/BeadledomConfigurationModuleSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/BeadledomConfigurationModuleSpec.scala
@@ -7,15 +7,17 @@ import javax.naming.{Context, InitialContext}
 import org.apache.commons.configuration2.ex.ConfigurationException
 import org.apache.commons.configuration2.{CombinedConfiguration, Configuration, ImmutableHierarchicalConfiguration}
 import org.mockito.Mockito.{mock => _}
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import scala.collection.JavaConverters._
 import uk.org.lidalia.slf4jext.Level
 import uk.org.lidalia.slf4jtest.TestLoggerFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Specs for [[BeadledomConfigurationModule]].
  */
-class BeadledomConfigurationModuleSpec extends FunSpec with BeforeAndAfter with MustMatchers {
+class BeadledomConfigurationModuleSpec extends AnyFunSpec with BeforeAndAfter with Matchers {
 
   System.setProperty(Context.INITIAL_CONTEXT_FACTORY,
     "org.apache.naming.java.javaURLContextFactory")

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/ConfigurationSourceModuleBuilderSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/ConfigurationSourceModuleBuilderSpec.scala
@@ -4,13 +4,15 @@ import com.google.inject._
 import java.io.FileReader
 import javax.naming.{Context, InitialContext}
 import org.apache.commons.configuration2.CombinedConfiguration
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import scala.collection.JavaConverters._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Specs for [[ConfigurationSourcesModuleBuilder]].
  */
-class ConfigurationSourceModuleBuilderSpec extends FunSpec with BeforeAndAfter with MustMatchers {
+class ConfigurationSourceModuleBuilderSpec extends AnyFunSpec with BeforeAndAfter with Matchers {
   System.setProperty(Context.INITIAL_CONTEXT_FACTORY,
     "org.apache.naming.java.javaURLContextFactory")
   System.setProperty(Context.URL_PKG_PREFIXES, "org.apache.naming")

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/EnvironmentConfigurationSourceSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/EnvironmentConfigurationSourceSpec.scala
@@ -1,13 +1,15 @@
 package com.cerner.beadledom.configuration
 
 import org.apache.commons.configuration2.{Configuration, EnvironmentConfiguration}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Specs for [[EnvironmentConfigurationSource]].
   */
 class EnvironmentConfigurationSourceSpec
-    extends FunSpec with BeforeAndAfterAll with MustMatchers {
+    extends AnyFunSpec with BeforeAndAfterAll with Matchers {
 
   describe("EnvironmentConfigurationSource") {
 

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/JndiConfigurationSourceSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/JndiConfigurationSourceSpec.scala
@@ -2,12 +2,14 @@ package com.cerner.beadledom.configuration
 
 import javax.naming.{Context, InitialContext}
 import org.apache.commons.configuration2.Configuration
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Specs for [[JndiConfigurationSource]].
  */
-class JndiConfigurationSourceSpec extends FunSpec with BeforeAndAfter with MustMatchers {
+class JndiConfigurationSourceSpec extends AnyFunSpec with BeforeAndAfter with Matchers {
 
   System.setProperty(Context.INITIAL_CONTEXT_FACTORY,
     "org.apache.naming.java.javaURLContextFactory")

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/PropertiesConfigurationSourceSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/PropertiesConfigurationSourceSpec.scala
@@ -2,12 +2,14 @@ package com.cerner.beadledom.configuration
 
 import java.io._
 import org.apache.commons.configuration2.Configuration
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Specs for [[PropertiesConfigurationSource]].
  */
-class PropertiesConfigurationSourceSpec extends FunSpec with BeforeAndAfter with MustMatchers {
+class PropertiesConfigurationSourceSpec extends AnyFunSpec with BeforeAndAfter with Matchers {
 
   var reader: Reader = _
 

--- a/configuration/src/test/scala/com/cerner/beadledom/configuration/XmlConfigurationSourceSpec.scala
+++ b/configuration/src/test/scala/com/cerner/beadledom/configuration/XmlConfigurationSourceSpec.scala
@@ -2,13 +2,15 @@ package com.cerner.beadledom.configuration
 
 import java.io.{File, FileReader, Reader}
 import org.apache.commons.configuration2.Configuration
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import scala.xml.XML
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Specs for [[XmlConfigurationSource]].
  */
-class XmlConfigurationSourceSpec extends FunSpec with BeforeAndAfter with MustMatchers {
+class XmlConfigurationSourceSpec extends AnyFunSpec with BeforeAndAfter with Matchers {
   var reader: Reader = _
 
   before {

--- a/docs/source/releases/Beadledom40.rst
+++ b/docs/source/releases/Beadledom40.rst
@@ -64,11 +64,57 @@ Scalatest provides autofix mechanisms for this upgrade, but requires multiples s
           </dependency>
         </dependencies>
       </plugin>
-  * Add a new file to the root of your project called .scalafix.conf with the following contents
+  * Add a new file to the root of your project called `.scalafix.conf` with the following contents
     ..code-block::
       rules = [
         RenameDeprecatedPackage
       ]
   * Run `mvn clean install scalafix:scalafix` and fix any errors until you get a fully successful build.
 2. Upgrade scalatest to 3.1.1+ with the updated autofix
+  * scalatest version: 3.1.1+
+  * Update scalafix-maven-plugin configuration
+    .. code-block:: xml
+      <plugin>
+      <groupId>io.github.evis</groupId>
+      <artifactId>scalafix-maven-plugin</artifactId>
+      <version>0.1.2_0.9.5</version>
+      <dependencies>
+        <dependency>
+          <groupId>org.scalatest</groupId>
+          <artifactId>autofix_${scala.binary.version}</artifactId>
+          <version>3.1.0.0</version>
+        </dependency>
+      </dependencies>
+    </plugin>
+  * Add the newly modularized scalatest jars to your dependency management and dependencies. The below dependencies are the most commonly used ones, but there may be others you'll need to add.
+    .. code-block:: xml
+      <dependency>
+        <groupId>org.scalatestplus</groupId>
+        <artifactId>junit-4-12_${scala.binary.version}</artifactId>
+        <version>3.1.1.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatestplus</groupId>
+        <artifactId>mockito-3-2_${scala.binary.version}</artifactId>
+        <version>3.1.1.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatestplus</groupId>
+        <artifactId>scalacheck-1-14_${scala.binary.version}</artifactId>
+        <version>3.1.1.0</version>
+        <scope>test</scope>
+      </dependency>
+  * Update the contents of your `.scalafix.conf` file
+    .. code-block:: xml
+      rules = [
+        RewriteDeprecatedNames
+      ]
+  * Run `mvn clean install scalafix:scalafix` and fix any errors until you get a fully successful build.
+  * Manually fix broken imports due to the switch to the modularized jars above and continue the above command until the entire thing succeeds.
+3. Remove the scalafix and autofix configurations
+  * Delete the `.scalafix.conf` file
+  * Remove the scalafix-maven-plugin
+  * Remove the semanticdb compiler plugin
 

--- a/docs/source/releases/Beadledom40.rst
+++ b/docs/source/releases/Beadledom40.rst
@@ -28,3 +28,47 @@ on beadledom-swagger1 to beadledom-swagger2. The user guide for beadledom-swagge
 
 The beadledom-stagemonitor module was removed. This will require updating your poms that have a dependency
 on beadledom-stagemonitor.
+
+Upgrading to Scala 2.12 and Scalatest 3.1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Beadledom upgraded to Scala 2.12 and Scalatest 3.1. If your project depends on any of the Scala functionality provided by Beadledom (naming beadledom-testing), then you will also need to upgrade these dependencies. It's best to make these upgrades even if you don't depend on the Scala functionality from Beadledom.
+
+Scalatest provides autofix mechanisms for this upgrade, but requires multiples steps.
+
+1. Upgrade to the latest Scala 2.12 version and scalatest 3.0.8 to use the scalatest autofixes for 3.0.8
+  * Scala binary version: 2.12
+  * Scala version: 2.12.11+
+  * scala-maven-plugin version: 4.3.1+
+  * scalacheck version: 1.14.3+
+  * scalatest version: 3.0.8
+  * Add semanticdb compiler plugin to the scala-maven-plugin configuration
+    .. code-block:: xml
+      <compilerPlugins>
+        <compilerPlugin>
+          <groupId>org.scalameta</groupId>
+          <artifactId>semanticdb-scalac_${scala.version}</artifactId>
+          <version>4.3.7</version>
+        </compilerPlugin>
+      </compilerPlugins>
+  * Add scalafix-maven-plugin with the scalatest autofix version 3.0.8-0 dependency to your pom file
+    .. code-block:: xml
+      <plugin>
+        <groupId>io.github.evis</groupId>
+        <artifactId>scalafix-maven-plugin</artifactId>
+        <version>0.1.2_0.9.5</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>autofix_${scala.binary.version}</artifactId>
+            <version>3.0.8-0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+  * Add a new file to the root of your project called .scalafix.conf with the following contents
+    ..code-block::
+      rules = [
+        RenameDeprecatedPackage
+      ]
+  * Run `mvn clean install scalafix:scalafix` and fix any errors until you get a fully successful build.
+2. Upgrade scalatest to 3.1.1+ with the updated autofix
+

--- a/guice-dynamicbindings/src/test/scala/com/cerner/beadledom/guice/dynamicbindings/AnnotatedModuleSpec.scala
+++ b/guice-dynamicbindings/src/test/scala/com/cerner/beadledom/guice/dynamicbindings/AnnotatedModuleSpec.scala
@@ -1,14 +1,15 @@
 package com.cerner.beadledom.guice.dynamicbindings
 
 import com.google.inject._
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[AnnotatedModule]].
   *
   * @author John Leacox
   */
-class AnnotatedModuleSpec extends FunSpec with MustMatchers {
+class AnnotatedModuleSpec extends AnyFunSpec with Matchers {
   describe("AnnotatedModule") {
     describe("constructor") {
       it("throws an IllegalArgumentException for a non-binding annotation") {

--- a/guice-dynamicbindings/src/test/scala/com/cerner/beadledom/guice/dynamicbindings/DynamicAnnotationsSpec.scala
+++ b/guice-dynamicbindings/src/test/scala/com/cerner/beadledom/guice/dynamicbindings/DynamicAnnotationsSpec.scala
@@ -1,14 +1,15 @@
 package com.cerner.beadledom.guice.dynamicbindings
 
 import com.google.inject._
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[DynamicAnnotations]].
   *
   * @author John Leacox
   */
-class DynamicAnnotationsSpec extends FunSpec with MustMatchers {
+class DynamicAnnotationsSpec extends AnyFunSpec with Matchers {
   describe("DynamicAnnotations") {
     describe("#bindDynamicProvider") {
       describe("with a class") {

--- a/guice-dynamicbindings/src/test/scala/com/cerner/beadledom/guice/dynamicbindings/DynamicBindingProviderImplSpec.scala
+++ b/guice-dynamicbindings/src/test/scala/com/cerner/beadledom/guice/dynamicbindings/DynamicBindingProviderImplSpec.scala
@@ -1,14 +1,15 @@
 package com.cerner.beadledom.guice.dynamicbindings
 
 import com.google.inject.{AbstractModule, Guice, Key, TypeLiteral}
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[DynamicBindingProviderImpl]].
   *
   * @author John Leacox
   */
-class DynamicBindingProviderImplSpec extends FunSpec with MustMatchers {
+class DynamicBindingProviderImplSpec extends AnyFunSpec with Matchers {
   describe("DynamicBindingProvider") {
     describe("#get") {
       it("returns the same instance for a singleton binding across multiple calls") {

--- a/guice/src/test/scala/com/cerner/beadledom/guice/BindingAnnotationsSpec.scala
+++ b/guice/src/test/scala/com/cerner/beadledom/guice/BindingAnnotationsSpec.scala
@@ -1,13 +1,15 @@
 package com.cerner.beadledom.guice
 
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[BindingAnnotations]].
   *
   * @author John Leacox
   */
-class BindingAnnotationsSpec extends FunSpec with MustMatchers with BeforeAndAfter {
+class BindingAnnotationsSpec extends AnyFunSpec with Matchers with BeforeAndAfter {
   describe("BindingAnnotations") {
     describe("#isBindingAnnotation") {
       it("returns false for a non-binding annotation") {

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/BuildDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/BuildDtoSpec.scala
@@ -1,8 +1,9 @@
 package com.cerner.beadledom.health.dto
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class BuildDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class BuildDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
 
   val buildDto = BuildDto.builder()
                  .setArtifactName("some name")

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDependenciesDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDependenciesDtoSpec.scala
@@ -1,10 +1,11 @@
 package com.cerner.beadledom.health.dto
 
-import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.collection.JavaConverters._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class HealthDependenciesDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class HealthDependenciesDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
 
   val healthDependency = HealthDependencyDto.builder()
                          .setHealthy(true)

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDependencyDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDependencyDtoSpec.scala
@@ -2,9 +2,10 @@ package com.cerner.beadledom.health.dto
 
 import java.util.Optional
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class HealthDependencyDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class HealthDependencyDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
   describe("HealthDependencyDto.Builder") {
     it("builds an object correctly") {
       val links = LinksDto.builder().setSelf("localhost").build()

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDtoSpec.scala
@@ -8,10 +8,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 class HealthDtoSpec extends FunSpec with MustMatchers with MockitoSugar {
   describe("HealthDto") {

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/HealthDtoSpec.scala
@@ -8,12 +8,13 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.mockito.Mockito.when
-import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class HealthDtoSpec extends FunSpec with MustMatchers with MockitoSugar {
+class HealthDtoSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("HealthDto") {
     describe(".builder(ServiceMetadata)") {
       it("initializes fields based on the metadata") {

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/HttpServiceDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/HttpServiceDtoSpec.scala
@@ -1,8 +1,9 @@
 package com.cerner.beadledom.health.dto
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class HttpServiceDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class HttpServiceDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
 
   val dto = HttpServiceDto.builder()
             .setStatus(200)

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/JacksonSerializationBehaviors.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/JacksonSerializationBehaviors.scala
@@ -3,14 +3,15 @@ package com.cerner.beadledom.health.dto
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Testing behaviors Jackson JSON serialization
   *
   * @author Nathan Schile
   */
-trait JacksonSerializationBehaviors { this: FunSpec with MustMatchers =>
+trait JacksonSerializationBehaviors { this: AnyFunSpec with Matchers =>
 
   val mapper = new ObjectMapper()
   mapper.registerModule(new Jdk8Module)

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/LinksDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/LinksDtoSpec.scala
@@ -1,8 +1,9 @@
 package com.cerner.beadledom.health.dto
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class LinksDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class LinksDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
 
   val dto = LinksDto.builder()
     .setSelf("self").build()

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/ServerDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/ServerDtoSpec.scala
@@ -2,9 +2,10 @@ package com.cerner.beadledom.health.dto
 
 import java.time.Instant
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class ServerDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class ServerDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
 
   val dto = ServerDto.builder()
     .setHostName("host")

--- a/health/api/src/test/scala/com/cerner/beadledom/health/dto/TypeDtoSpec.scala
+++ b/health/api/src/test/scala/com/cerner/beadledom/health/dto/TypeDtoSpec.scala
@@ -1,8 +1,9 @@
 package com.cerner.beadledom.health.dto
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class TypeDtoSpec extends FunSpec with MustMatchers with JacksonSerializationBehaviors {
+class TypeDtoSpec extends AnyFunSpec with Matchers with JacksonSerializationBehaviors {
 
   val httpServiceDto = HttpServiceDto.builder()
     .setStatus(200)

--- a/health/service/src/test/scala/com/cerner/beadledom/health/HealthModuleSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/HealthModuleSpec.scala
@@ -3,9 +3,9 @@ package com.cerner.beadledom.health
 import com.cerner.beadledom.metadata.ServiceMetadata
 import com.google.inject._
 import com.google.inject.multibindings.{Multibinder, ProvidesIntoSet}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import javax.ws.rs.core.UriInfo
+import org.scalatestplus.mockito.MockitoSugar
 
 class HealthModuleSpec extends FunSpec with MustMatchers with MockitoSugar {
   val mockModule = new AbstractModule {

--- a/health/service/src/test/scala/com/cerner/beadledom/health/HealthModuleSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/HealthModuleSpec.scala
@@ -3,11 +3,12 @@ package com.cerner.beadledom.health
 import com.cerner.beadledom.metadata.ServiceMetadata
 import com.google.inject._
 import com.google.inject.multibindings.{Multibinder, ProvidesIntoSet}
-import org.scalatest.{FunSpec, MustMatchers}
 import javax.ws.rs.core.UriInfo
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class HealthModuleSpec extends FunSpec with MustMatchers with MockitoSugar {
+class HealthModuleSpec extends AnyFunSpec with Matchers with MockitoSugar {
   val mockModule = new AbstractModule {
     override def configure(): Unit = {
       bind(classOf[ServiceMetadata]).toInstance(mock[ServiceMetadata])

--- a/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
@@ -13,7 +13,7 @@ import org.mockito.Mockito.when
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class HealthCheckerSpec extends AnyFunSpec with Matchers with MockitoSugar {
   val buildInfo = mock[BuildInfo]
@@ -32,7 +32,7 @@ class HealthCheckerSpec extends AnyFunSpec with Matchers with MockitoSugar {
   def newChecker(requestUri: String, dependencies: List[HealthDependency]) = new HealthChecker(
     new ResteasyUriInfo(new URI(requestUri)),
     metadata,
-    dependencies.groupBy(d => d.getName).view.mapValues(ds => ds.head).toMap.asJava
+    dependencies.groupBy(d => d.getName).mapValues(ds => ds.head).asJava
   )
 
   def newDependency(name: String, desc: String,

--- a/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
@@ -11,10 +11,10 @@ import com.cerner.beadledom.metadata.{BuildInfo, ServiceMetadata}
 import javax.ws.rs.WebApplicationException
 import org.jboss.resteasy.spi.ResteasyUriInfo
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 class HealthCheckerSpec extends FunSpec with MustMatchers with MockitoSugar {
   val buildInfo = mock[BuildInfo]

--- a/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
@@ -11,12 +11,13 @@ import com.cerner.beadledom.metadata.{BuildInfo, ServiceMetadata}
 import javax.ws.rs.WebApplicationException
 import org.jboss.resteasy.spi.ResteasyUriInfo
 import org.mockito.Mockito.when
-import org.scalatest.{FunSpec, MustMatchers}
 
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class HealthCheckerSpec extends FunSpec with MustMatchers with MockitoSugar {
+class HealthCheckerSpec extends AnyFunSpec with Matchers with MockitoSugar {
   val buildInfo = mock[BuildInfo]
   val dateTime: Optional[String] = Optional.of("2016-02-03T04:05:06Z")
   when(buildInfo.getBuildDateTime).thenReturn(dateTime)

--- a/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthCheckerSpec.scala
@@ -1,21 +1,19 @@
 package com.cerner.beadledom.health.internal
 
+import com.cerner.beadledom.health.dto.{HealthDependencyDto, HealthDto, LinksDto}
+import com.cerner.beadledom.health.{HealthDependency, HealthStatus}
+import com.cerner.beadledom.metadata.{BuildInfo, ServiceMetadata}
 import java.lang
 import java.net.URI
 import java.time.Instant
 import java.util.Optional
-
-import com.cerner.beadledom.health.dto.{HealthDependencyDto, HealthDto, LinksDto}
-import com.cerner.beadledom.health.{HealthDependency, HealthStatus}
-import com.cerner.beadledom.metadata.{BuildInfo, ServiceMetadata}
 import javax.ws.rs.WebApplicationException
 import org.jboss.resteasy.spi.ResteasyUriInfo
 import org.mockito.Mockito.when
-
-import scala.collection.JavaConverters._
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import scala.jdk.CollectionConverters._
 
 class HealthCheckerSpec extends AnyFunSpec with Matchers with MockitoSugar {
   val buildInfo = mock[BuildInfo]
@@ -34,7 +32,7 @@ class HealthCheckerSpec extends AnyFunSpec with Matchers with MockitoSugar {
   def newChecker(requestUri: String, dependencies: List[HealthDependency]) = new HealthChecker(
     new ResteasyUriInfo(new URI(requestUri)),
     metadata,
-    dependencies.groupBy(d => d.getName).mapValues(ds => ds.head).asJava
+    dependencies.groupBy(d => d.getName).view.mapValues(ds => ds.head).toMap.asJava
   )
 
   def newDependency(name: String, desc: String,

--- a/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthDependencyPresenterSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthDependencyPresenterSpec.scala
@@ -4,13 +4,15 @@ import com.cerner.beadledom.health.dto.{HealthDependencyDto, LinksDto}
 import com.cerner.beadledom.health.internal.presenter.HealthDependencyPresenter
 import org.scalatest._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec tests for HealthDependencyPresenter.
  *
  * @author John Leacox
  */
-class HealthDependencyPresenterSpec extends FunSpec with MustMatchers with MockitoSugar {
+class HealthDependencyPresenterSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("HealthDependencyPresenter") {
     val healthDependencyDto = HealthDependencyDto.builder()
         .setName("abra")

--- a/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthDependencyPresenterSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/internal/HealthDependencyPresenterSpec.scala
@@ -3,7 +3,7 @@ package com.cerner.beadledom.health.internal
 import com.cerner.beadledom.health.dto.{HealthDependencyDto, LinksDto}
 import com.cerner.beadledom.health.internal.presenter.HealthDependencyPresenter
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec tests for HealthDependencyPresenter.

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/AvailabilityResourceImplSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/AvailabilityResourceImplSpec.scala
@@ -5,13 +5,15 @@ import com.github.mustachejava.DefaultMustacheFactory
 import org.scalatest._
 import java.time.Instant
 import java.util.{Properties, Optional}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec tests for AvailabilityResourceImpl.
  *
  * @author John Leacox
  */
-class AvailabilityResourceImplSpec extends FunSpec with MustMatchers {
+class AvailabilityResourceImplSpec extends AnyFunSpec with Matchers {
   describe("AvailabilityResourceImpl") {
     describe("#getBasicAvailabilityCheck") {
       it("returns a dto with status 200") {

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/BaseSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/BaseSpec.scala
@@ -9,8 +9,9 @@ import com.github.mustachejava.DefaultMustacheFactory
 import javax.ws.rs.core.{UriBuilder, UriInfo}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.{FunSpec, MustMatchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Base Spec for resource tests that provides a create dependency method
@@ -18,7 +19,7 @@ import org.scalatestplus.mockito.MockitoSugar
   *
   * @author Nick Behrens
   */
-class BaseSpec extends FunSpec with MustMatchers with MockitoSugar {
+class BaseSpec extends AnyFunSpec with Matchers with MockitoSugar {
 
   protected val mockUriInfo: UriInfo = mock[UriInfo]
   private val mockUriBuilder = mock[UriBuilder]

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/BaseSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/BaseSpec.scala
@@ -9,8 +9,8 @@ import com.github.mustachejava.DefaultMustacheFactory
 import javax.ws.rs.core.{UriBuilder, UriInfo}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Base Spec for resource tests that provides a create dependency method

--- a/health/service/src/test/scala/com/cerner/beadledom/health/resource/VersionResourceImplSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/resource/VersionResourceImplSpec.scala
@@ -6,13 +6,15 @@ import java.util.Properties
 import com.cerner.beadledom.metadata.{BuildInfo, ServiceMetadata}
 import com.github.mustachejava.DefaultMustacheFactory
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Spec tests for VersionResourceImpl.
   *
   * @author Nimesh Subramanian
   */
-class VersionResourceImplSpec extends FunSpec with MustMatchers {
+class VersionResourceImplSpec extends AnyFunSpec with Matchers {
   describe("VersionResourceImpl") {
     describe("#getVersionInfo") {
       it("returns a dto with status 200") {

--- a/integration/test/src/test/scala/com/beadledom/integration/test/ForwardedHeaderFilterSpec.scala
+++ b/integration/test/src/test/scala/com/beadledom/integration/test/ForwardedHeaderFilterSpec.scala
@@ -7,10 +7,9 @@ import com.google.inject.{AbstractModule, Guice, Injector}
 import java.io.{BufferedReader, InputStream, InputStreamReader}
 import java.net.URL
 import java.util.stream.Collectors
-import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Integration Tests that make service requests through a self-signed reverse proxy to test the behavior

--- a/integration/test/src/test/scala/com/beadledom/integration/test/ForwardedHeaderFilterSpec.scala
+++ b/integration/test/src/test/scala/com/beadledom/integration/test/ForwardedHeaderFilterSpec.scala
@@ -8,8 +8,11 @@ import java.io.{BufferedReader, InputStream, InputStreamReader}
 import java.net.URL
 import java.util.stream.Collectors
 import org.junit.runner.RunWith
-import org.scalatest.{BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.junit.JUnitRunner
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Integration Tests that make service requests through a self-signed reverse proxy to test the behavior
@@ -18,7 +21,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author Nick Behrens
  */
 @RunWith(classOf[JUnitRunner])
-class ForwardedHeaderFilterSpec extends FunSpec with MustMatchers with MockitoSugar with BeforeAndAfterAll {
+class ForwardedHeaderFilterSpec extends AnyFunSpec with Matchers with MockitoSugar with BeforeAndAfterAll {
 
   val baseUri = s"https://localhost/beadledom-integration-service"
 

--- a/jackson/src/test/scala/com/cerner/beadledom/jackson/JacksonModuleSpec.scala
+++ b/jackson/src/test/scala/com/cerner/beadledom/jackson/JacksonModuleSpec.scala
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, ObjectMapper, SerializationFeature}
 import com.google.inject.multibindings.MultibindingsScanner
 import com.google.inject.{AbstractModule, Guice}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec tests for {@link JacksonModule}.

--- a/jackson/src/test/scala/com/cerner/beadledom/jackson/JacksonModuleSpec.scala
+++ b/jackson/src/test/scala/com/cerner/beadledom/jackson/JacksonModuleSpec.scala
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, ObjectMapper, SerializationFeature}
 import com.google.inject.multibindings.MultibindingsScanner
 import com.google.inject.{AbstractModule, Guice}
-import org.scalatest.{FunSpec, Matchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Spec tests for {@link JacksonModule}.
  */
-class JacksonModuleSpec extends FunSpec with Matchers with MockitoSugar {
+class JacksonModuleSpec extends AnyFunSpec with Matchers with MockitoSugar {
   val injector = Guice.createInjector(new AbstractModule() {
     override def configure(): Unit = {
       install(new JacksonTestModule)

--- a/jackson/src/test/scala/com/cerner/beadledom/jackson/filter/FieldFilterSpec.scala
+++ b/jackson/src/test/scala/com/cerner/beadledom/jackson/filter/FieldFilterSpec.scala
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.databind.util.TokenBuffer
 import com.google.common.collect.Lists
 import java.io.ByteArrayOutputStream
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Field filter spec for testing different serialization cases.

--- a/jackson/src/test/scala/com/cerner/beadledom/jackson/filter/FieldFilterSpec.scala
+++ b/jackson/src/test/scala/com/cerner/beadledom/jackson/filter/FieldFilterSpec.scala
@@ -10,11 +10,13 @@ import java.io.ByteArrayOutputStream
 import org.scalatest._
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Field filter spec for testing different serialization cases.
  */
-class FieldFilterSpec extends FunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
+class FieldFilterSpec extends AnyFunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
 
   describe("Processing of fields for the field filter.") {
     it("Handles fields with trailing slashes.") {

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/DelegatingGenericResponseSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/DelegatingGenericResponseSpec.scala
@@ -9,8 +9,8 @@ import javax.ws.rs.core._
 
 import org.mockito.Mockito._
 import org.scalacheck.Gen
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 /**
   * Spec tests for [[DelegatingGenericResponse]].
@@ -18,7 +18,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
   * @author John Leacox
   */
 class DelegatingGenericResponseSpec
-    extends UnitSpec with MockitoSugar with GeneratorDrivenPropertyChecks {
+    extends UnitSpec with MockitoSugar with ScalaCheckDrivenPropertyChecks {
   describe("DelegatingGenericResponse") {
     describe("#create") {
       it("creates a new instance of DelegatingGenericResponse") {

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/GenericResponseBuilderSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/GenericResponseBuilderSpec.scala
@@ -8,8 +8,8 @@ import javax.ws.rs.core.Response.StatusType
 import javax.ws.rs.core._
 import org.jboss.resteasy.specimpl.MultivaluedMapImpl
 import org.mockito.Mockito.{verify, when}
-import org.scalatest.mockito.MockitoSugar
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Spec tests for [[GenericResponseBuilder]].

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/GenericResponsesSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/GenericResponsesSpec.scala
@@ -4,14 +4,15 @@ import java.net.URI
 import java.util.Locale
 import javax.ws.rs.core.Response.StatusType
 import javax.ws.rs.core.{EntityTag, MediaType, Response, Variant}
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Spec tests for [[GenericResponses]].
   *
   * @author John Leacox
   */
-class GenericResponsesSpec extends FunSpec with MustMatchers {
+class GenericResponsesSpec extends AnyFunSpec with Matchers {
   describe("GenericResponses") {
     describe("#fromResponse") {
       it("creates a new response with the same values (shallow copy) of the existing response") {

--- a/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/ResponseToStringWrapperSpec.scala
+++ b/jaxrs-genericresponse/src/test/scala/com/cerner/beadledom/jaxrs/ResponseToStringWrapperSpec.scala
@@ -8,7 +8,7 @@ import javax.ws.rs.core._
 
 import com.cerner.beadledom.testing.UnitSpec
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ResponseToStringWrapperSpec extends UnitSpec with MockitoSugar {
   describe("ResponseToStringWrapper") {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/JaxRsParamConditionsSpec.scala
@@ -2,7 +2,8 @@ package com.cerner.beadledom.jaxrs
 
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.MediaType
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec tests for {@link JaxRsParamConditions}.
@@ -10,7 +11,7 @@ import org.scalatest.{FunSpec, MustMatchers}
  * @author John Leacox
  * @author Nimesh Subramanian
  */
-class JaxRsParamConditionsSpec extends FunSpec with MustMatchers {
+class JaxRsParamConditionsSpec extends AnyFunSpec with Matchers {
   describe("JaxRsParamConditions") {
     describe("checkParam") {
       it("must throw WebApplicationException with 400 status when expression is false") {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/PATCHSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/PATCHSpec.scala
@@ -9,12 +9,12 @@ import org.jboss.resteasy.core.Dispatcher
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.jboss.resteasy.plugins.server.resourcefactory.POJOResourceFactory
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
 
 import java.io._
 
 import scala.collection.JavaConverters._
 import javax.ws.rs.core.MediaType
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Spec tests for {@link PATCH}.

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/PATCHSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/PATCHSpec.scala
@@ -15,13 +15,15 @@ import java.io._
 import scala.collection.JavaConverters._
 import javax.ws.rs.core.MediaType
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Spec tests for {@link PATCH}.
   *
   * @author Eric Christensen
   */
-class PATCHSpec extends FunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
+class PATCHSpec extends AnyFunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
 
     val dispatcher: Dispatcher = MockDispatcherFactory.createDispatcher()
     val noDefaults: POJOResourceFactory = new POJOResourceFactory(classOf[FakeResource])

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/StreamingWriterOutputSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/StreamingWriterOutputSpec.scala
@@ -3,13 +3,14 @@ package com.cerner.beadledom.jaxrs
 import com.google.common.base.Charsets
 import java.io.{ByteArrayOutputStream, OutputStreamWriter}
 import java.util.function.Consumer
-import org.scalatest.{FunSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * @author John Leacox
   */
-class StreamingWriterOutputSpec extends FunSpec with Matchers with MockitoSugar {
+class StreamingWriterOutputSpec extends AnyFunSpec with Matchers with MockitoSugar {
 
   implicit def toConsumer[A](function: A => Unit): Consumer[A] = new Consumer[A]() {
     override def accept(arg: A): Unit = function.apply(arg)

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/StreamingWriterOutputSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/StreamingWriterOutputSpec.scala
@@ -3,8 +3,8 @@ package com.cerner.beadledom.jaxrs
 import com.google.common.base.Charsets
 import java.io.{ByteArrayOutputStream, OutputStreamWriter}
 import java.util.function.Consumer
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * @author John Leacox

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonMappingExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonMappingExceptionMapperSpec.scala
@@ -11,8 +11,8 @@ import javax.ws.rs.core.Response.Status._
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Unit tests for [[JsonMappingExceptionMapper]].

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonMappingExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonMappingExceptionMapperSpec.scala
@@ -11,8 +11,10 @@ import javax.ws.rs.core.Response.Status._
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Unit tests for [[JsonMappingExceptionMapper]].
@@ -20,7 +22,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class JsonMappingExceptionMapperSpec
-    extends FunSpec with MustMatchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
+    extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
 
   val jsonMappingExceptionMapper = new JsonMappingExceptionMapper
   val fakeRepository = mock[FakeRepository]

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonParseExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonParseExceptionMapperSpec.scala
@@ -11,8 +11,10 @@ import javax.ws.rs.core.Response.Status.BAD_REQUEST
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Unit tests for [[JsonParseExceptionMapper]].
@@ -20,7 +22,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class JsonParseExceptionMapperSpec
-    extends FunSpec with MustMatchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
+    extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
 
   val jsonMappingExceptionMapper = new JsonParseExceptionMapper
   val fakeRepository = mock[FakeRepository]

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonParseExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/JsonParseExceptionMapperSpec.scala
@@ -11,8 +11,8 @@ import javax.ws.rs.core.Response.Status.BAD_REQUEST
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Unit tests for [[JsonParseExceptionMapper]].

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/ThrowableExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/ThrowableExceptionMapperSpec.scala
@@ -9,12 +9,14 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 import org.jboss.resteasy.mock._
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response.Status._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[ThrowableExceptionMapper]].
@@ -22,7 +24,7 @@ import org.scalatestplus.mockito.MockitoSugar
   * @author Cal Fisher
   */
 class ThrowableExceptionMapperSpec
-    extends FunSpec with MustMatchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
+    extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
 
   val throwableExceptionMapper = new ThrowableExceptionMapper
   val fakeRepository = mock[FakeRepository]

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/ThrowableExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/ThrowableExceptionMapperSpec.scala
@@ -9,12 +9,12 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 import org.jboss.resteasy.mock._
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
 
 import javax.ws.rs.core.HttpHeaders.CONTENT_TYPE
 import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response.Status._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[ThrowableExceptionMapper]].

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/WebApplicationExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/WebApplicationExceptionMapperSpec.scala
@@ -9,13 +9,13 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
 
 import javax.ws.rs._
 import javax.ws.rs.core.HttpHeaders._
 import javax.ws.rs.core.Response.Status._
 import javax.ws.rs.core.{MediaType, Response}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[WebApplicationExceptionMapper]].

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/WebApplicationExceptionMapperSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/exceptionmapping/WebApplicationExceptionMapperSpec.scala
@@ -9,13 +9,15 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider
 import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttpResponse}
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import javax.ws.rs._
 import javax.ws.rs.core.HttpHeaders._
 import javax.ws.rs.core.Response.Status._
 import javax.ws.rs.core.{MediaType, Response}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[WebApplicationExceptionMapper]].
@@ -23,7 +25,7 @@ import org.scalatestplus.mockito.MockitoSugar
   * @author Cal Fisher
   */
 class WebApplicationExceptionMapperSpec
-    extends FunSpec with MustMatchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
+    extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
 
   val webApplicationExceptionMapper = new WebApplicationExceptionMapper
   val fakeRepository = mock[FakeRepository]

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterBehaviors.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterBehaviors.scala
@@ -4,14 +4,16 @@ import javax.ws.rs.container.{ContainerRequestContext, ContainerResponseContext}
 import org.jboss.resteasy.core.Headers
 import org.mockito
 import org.mockito.{ArgumentCaptor, Mockito}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
 import org.slf4j.MDC
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author John Leacox
  */
 trait CorrelationIdFilterBehaviors extends BeforeAndAfter with Matchers {
-  this: FunSpec =>
+  this: AnyFunSpec =>
 
   def correlationIdFilter(filter: CorrelationIdFilter, headerName: String,
       mdcName: String): Unit = {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterSpec.scala
@@ -3,8 +3,10 @@ package com.cerner.beadledom.jaxrs.provider
 import org.scalatest._
 import org.slf4j.MDC
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class CorrelationIdFilterSpec extends FunSpec with BeforeAndAfter with Matchers
+class CorrelationIdFilterSpec extends AnyFunSpec with BeforeAndAfter with Matchers
 with MockitoSugar with CorrelationIdFilterBehaviors {
   val defaultHeaderName = "Correlation-Id"
   val defaultMdcName = "Correlation-Id"

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/CorrelationIdFilterSpec.scala
@@ -1,8 +1,8 @@
 package com.cerner.beadledom.jaxrs.provider
 
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
 import org.slf4j.MDC
+import org.scalatestplus.mockito.MockitoSugar
 
 class CorrelationIdFilterSpec extends FunSpec with BeforeAndAfter with Matchers
 with MockitoSugar with CorrelationIdFilterBehaviors {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/FilteringJacksonJsonProviderSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/FilteringJacksonJsonProviderSpec.scala
@@ -13,12 +13,14 @@ import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest._
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Spec tests for {@link FilteringJacksonJsonProvider}.
  */
 class FilteringJacksonJsonProviderSpec
-    extends FunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
+    extends AnyFunSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
 
   val objectMapper = new ObjectMapper()
 

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/FilteringJacksonJsonProviderSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/FilteringJacksonJsonProviderSpec.scala
@@ -11,8 +11,8 @@ import org.jboss.resteasy.specimpl.MultivaluedMapImpl
 import org.mockito
 import org.mockito.{ArgumentCaptor, Mockito}
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec tests for {@link FilteringJacksonJsonProvider}.

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/ForwardedHeaderFilterSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/ForwardedHeaderFilterSpec.scala
@@ -6,7 +6,7 @@ import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.core._
 import org.mockito.Mockito.{when,verify}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach, FunSpec, Matchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 class ForwardedHeaderFilterSpec extends FunSpec with BeforeAndAfter with Matchers with BeforeAndAfterEach
   with MockitoSugar {

--- a/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/ForwardedHeaderFilterSpec.scala
+++ b/jaxrs/src/test/scala/com/cerner/beadledom/jaxrs/provider/ForwardedHeaderFilterSpec.scala
@@ -5,10 +5,12 @@ import java.net.URI
 import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.core._
 import org.mockito.Mockito.{when,verify}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ForwardedHeaderFilterSpec extends FunSpec with BeforeAndAfter with Matchers with BeforeAndAfterEach
+class ForwardedHeaderFilterSpec extends AnyFunSpec with BeforeAndAfter with Matchers with BeforeAndAfterEach
   with MockitoSugar {
 
   def createContainerRequestContext: ContainerRequestContext = {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
@@ -2,9 +2,9 @@ package com.cerner.beadledom.jooq
 
 import javax.sql.DataSource
 import org.jooq.{DSLContext, SQLDialect}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
 import scala.collection.mutable
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for DSLContextProviderImpl.

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/DSLContextProviderImplSpec.scala
@@ -2,9 +2,11 @@ package com.cerner.beadledom.jooq
 
 import javax.sql.DataSource
 import org.jooq.{DSLContext, SQLDialect}
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import scala.collection.mutable
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for DSLContextProviderImpl.
@@ -12,7 +14,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class DSLContextProviderImplSpec extends
-    FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+    AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
   val transactionalHooks = new ThreadLocalJooqTransactionalHooks()
 
   before {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTransactionSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTransactionSpec.scala
@@ -1,7 +1,7 @@
 package com.cerner.beadledom.jooq
 
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for JooqTransaction.

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTransactionSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTransactionSpec.scala
@@ -1,14 +1,16 @@
 package com.cerner.beadledom.jooq
 
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for JooqTransaction.
  *
  * @author John Leacox
  */
-class JooqTransactionSpec extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+class JooqTransactionSpec extends AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
   describe("JooqTransaction") {
     describe("#addCommitHooks") {
       it("adds the actions to the transactions commit hooks") {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTxnInterceptorSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTxnInterceptorSpec.scala
@@ -6,8 +6,10 @@ import org.jooq.tools.jdbc._
 import org.jooq.{ConnectionProvider, ContextTransactionalCallable, DSLContext}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for JooqTxnInterceptor.
@@ -15,7 +17,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class JooqTxnInterceptorSpec
-    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+    extends AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
   describe("JooqTxnInterceptor") {
     describe("#invoke") {
       it("does not end the unit of work if it did not start it") {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTxnInterceptorSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/JooqTxnInterceptorSpec.scala
@@ -6,8 +6,8 @@ import org.jooq.tools.jdbc._
 import org.jooq.{ConnectionProvider, ContextTransactionalCallable, DSLContext}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{spy, times, verify, when}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for JooqTxnInterceptor.

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
@@ -2,8 +2,10 @@ package com.cerner.beadledom.jooq
 
 import org.jooq.TransactionContext
 import org.mockito.Mockito.reset
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for ThreadLocalCommitHookExecutingTransactionListener.
@@ -11,7 +13,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class ThreadLocalCommitHookExecutingTransactionListenerSpec
-    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+    extends AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
   val context = mock[TransactionContext]
 
   val transactionalHooks = new ThreadLocalJooqTransactionalHooks

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalCommitHookExecutingTransactionListenerSpec.scala
@@ -2,8 +2,8 @@ package com.cerner.beadledom.jooq
 
 import org.jooq.TransactionContext
 import org.mockito.Mockito.reset
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for ThreadLocalCommitHookExecutingTransactionListener.

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqModuleSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqModuleSpec.scala
@@ -5,8 +5,10 @@ import javax.sql.DataSource
 import org.jooq.SQLDialect
 import org.jooq.tools.jdbc.MockConnection
 import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for ThreadLocalJooqModule.
@@ -14,7 +16,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class ThreadLocalJooqModuleSpec
-    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+    extends AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
   describe("ThreadLocalJooqModule") {
     it("throws an IllegalStateException if a DataSource binding is missing") {
       val module = new AbstractModule {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqModuleSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqModuleSpec.scala
@@ -5,8 +5,8 @@ import javax.sql.DataSource
 import org.jooq.SQLDialect
 import org.jooq.tools.jdbc.MockConnection
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for ThreadLocalJooqModule.

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooksSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooksSpec.scala
@@ -1,7 +1,9 @@
 package com.cerner.beadledom.jooq
 
-import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatest.BeforeAndAfter
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for ThreadLocalJooqTransactionalHooks.
@@ -9,7 +11,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class ThreadLocalJooqTransactionalHooksSpec
-    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+    extends AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
   describe("ThreadLocalJooqTransactionalHooks") {
     describe("#whenCommitted") {
       it("throws a NullPointerException if action is null") {

--- a/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooksSpec.scala
+++ b/jooq/src/test/scala/com/cerner/beadledom/jooq/ThreadLocalJooqTransactionalHooksSpec.scala
@@ -1,7 +1,7 @@
 package com.cerner.beadledom.jooq
 
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for ThreadLocalJooqTransactionalHooks.

--- a/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorBuilderSpec.scala
+++ b/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorBuilderSpec.scala
@@ -3,9 +3,9 @@ package com.cerner.beadledom.lifecycle.governator
 import com.google.inject.{AbstractModule, Module}
 import com.netflix.governator.LifecycleManager
 import com.netflix.governator.ShutdownHookModule.SystemShutdownHook
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[GovernatorLifecycleInjectorBuilder]].

--- a/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorBuilderSpec.scala
+++ b/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorBuilderSpec.scala
@@ -3,16 +3,17 @@ package com.cerner.beadledom.lifecycle.governator
 import com.google.inject.{AbstractModule, Module}
 import com.netflix.governator.LifecycleManager
 import com.netflix.governator.ShutdownHookModule.SystemShutdownHook
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[GovernatorLifecycleInjectorBuilder]].
   *
   * @author John Leacox
   */
-class GovernatorLifecycleInjectorBuilderSpec extends FunSpec with MustMatchers with MockitoSugar {
+class GovernatorLifecycleInjectorBuilderSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("GovernatorLifecycleInjectorBuilder") {
     describe("#modules") {
       it("throws a NullPointerException if the modules param is null") {

--- a/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorSpec.scala
+++ b/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorSpec.scala
@@ -3,9 +3,9 @@ package com.cerner.beadledom.lifecycle.governator
 import com.google.inject.{AbstractModule, Module}
 import com.netflix.governator.InjectorBuilder
 import javax.annotation.PreDestroy
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[GovernatorLifecycleInjector]]

--- a/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorSpec.scala
+++ b/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/GovernatorLifecycleInjectorSpec.scala
@@ -3,16 +3,17 @@ package com.cerner.beadledom.lifecycle.governator
 import com.google.inject.{AbstractModule, Module}
 import com.netflix.governator.InjectorBuilder
 import javax.annotation.PreDestroy
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[GovernatorLifecycleInjector]]
   *
   * @author John Leacox
   */
-class GovernatorLifecycleInjectorSpec extends FunSpec with MustMatchers with MockitoSugar {
+class GovernatorLifecycleInjectorSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("GovernatorLifecycleInjector") {
     describe("#shutdown") {
       it("executes shutdown on the governator injector") {

--- a/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/LifecycleInjectorBuilderSpec.scala
+++ b/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/LifecycleInjectorBuilderSpec.scala
@@ -3,9 +3,9 @@ package com.cerner.beadledom.lifecycle.governator
 import com.cerner.beadledom.lifecycle.LifecycleInjectorBuilder
 import com.google.inject.{AbstractModule, Module}
 import java.util.Collections
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[LifecycleInjectorBuilder]].

--- a/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/LifecycleInjectorBuilderSpec.scala
+++ b/lifecycle-governator/src/test/scala/com/cerner/beadledom/lifecycle/governator/LifecycleInjectorBuilderSpec.scala
@@ -3,16 +3,17 @@ package com.cerner.beadledom.lifecycle.governator
 import com.cerner.beadledom.lifecycle.LifecycleInjectorBuilder
 import com.google.inject.{AbstractModule, Module}
 import java.util.Collections
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[LifecycleInjectorBuilder]].
   *
   * @author John Leacox
   */
-class LifecycleInjectorBuilderSpec extends FunSpec with MustMatchers with MockitoSugar {
+class LifecycleInjectorBuilderSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("Governator LifecycleInjectorBuilder") {
     describe("#fromModules") {
       it("defaults to the governator implementation, if found on classpath") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/DelegatingInjectorSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/DelegatingInjectorSpec.scala
@@ -4,13 +4,15 @@ import com.google.inject.{Injector, Key, Module, TypeLiteral}
 import org.mockito.Mockito
 import org.scalatest._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[DelegatingInjector]].
   *
   * @author John Leacox
   */
-class DelegatingInjectorSpec extends FunSpec with MustMatchers with MockitoSugar {
+class DelegatingInjectorSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("DelegatingInjector") {
     describe("constructor") {
       it("throws a NullPointerException for a null injector parameter") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/DelegatingInjectorSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/DelegatingInjectorSpec.scala
@@ -3,7 +3,7 @@ package com.cerner.beadledom.lifecycle
 import com.google.inject.{Injector, Key, Module, TypeLiteral}
 import org.mockito.Mockito
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[DelegatingInjector]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/GuiceLifecycleContainersSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/GuiceLifecycleContainersSpec.scala
@@ -3,16 +3,17 @@ package com.cerner.beadledom.lifecycle
 import com.google.inject.{AbstractModule, Inject, Module}
 import java.util.Collections
 import javax.annotation.{PostConstruct, PreDestroy}
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[GuiceLifecycleContainers]].
   *
   * @author John Leacox
   */
-class GuiceLifecycleContainersSpec extends FunSpec with MustMatchers with MockitoSugar {
+class GuiceLifecycleContainersSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("GuiceLifecycleContainers") {
     describe("#initialize") {
       it("throws a NullPointerException for a null container") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/GuiceLifecycleContainersSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/GuiceLifecycleContainersSpec.scala
@@ -3,9 +3,9 @@ package com.cerner.beadledom.lifecycle
 import com.google.inject.{AbstractModule, Inject, Module}
 import java.util.Collections
 import javax.annotation.{PostConstruct, PreDestroy}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[GuiceLifecycleContainers]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/LifecycleInjectorBuilderSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/LifecycleInjectorBuilderSpec.scala
@@ -3,16 +3,17 @@ package com.cerner.beadledom.lifecycle
 import com.cerner.beadledom.lifecycle.legacy.BeadledomLifecycleInjectorBuilder
 import com.google.inject.{AbstractModule, Module}
 import java.util.Collections
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[LifecycleInjectorBuilder]].
   *
   * @author John Leacox
   */
-class LifecycleInjectorBuilderSpec extends FunSpec with MustMatchers with MockitoSugar {
+class LifecycleInjectorBuilderSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("Beadledom LifecycleInjectorBuilder") {
     describe("#fromModules") {
       it("Creates an instance of BeadledomLifecycleInjectorBuilder if governator is not found") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/LifecycleInjectorBuilderSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/LifecycleInjectorBuilderSpec.scala
@@ -3,9 +3,9 @@ package com.cerner.beadledom.lifecycle
 import com.cerner.beadledom.lifecycle.legacy.BeadledomLifecycleInjectorBuilder
 import com.google.inject.{AbstractModule, Module}
 import java.util.Collections
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[LifecycleInjectorBuilder]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorBuilderSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorBuilderSpec.scala
@@ -2,9 +2,9 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import com.cerner.beadledom.lifecycle.legacy.ShutdownHookModule.SystemShutdownHook
 import com.google.inject.{AbstractModule, Module}
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[BeadledomLifecycleInjectorBuilder]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorBuilderSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorBuilderSpec.scala
@@ -2,16 +2,17 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import com.cerner.beadledom.lifecycle.legacy.ShutdownHookModule.SystemShutdownHook
 import com.google.inject.{AbstractModule, Module}
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[BeadledomLifecycleInjectorBuilder]].
   *
   * @author John Leacox
   */
-class BeadledomLifecycleInjectorBuilderSpec extends FunSpec with MustMatchers with MockitoSugar {
+class BeadledomLifecycleInjectorBuilderSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("BeadledomLifecycleInjectorBuilder") {
     describe("#modules") {
       it("throws a NullPointerException if the modules param is null") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorSpec.scala
@@ -2,15 +2,16 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import com.google.inject.Injector
 import org.mockito.Mockito
-import org.scalatest.{FunSpec, MustMatchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[BeadledomLifecycleInjector]].
   *
   * @author John Leacox
   */
-class BeadledomLifecycleInjectorSpec extends FunSpec with MustMatchers with MockitoSugar {
+class BeadledomLifecycleInjectorSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("BeadledomLifecycleInjector") {
     describe("#shutdown") {
       it("executes shutdown on the shutdown manager") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleInjectorSpec.scala
@@ -2,8 +2,8 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import com.google.inject.Injector
 import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[BeadledomLifecycleInjector]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleModuleSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleModuleSpec.scala
@@ -2,8 +2,8 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import com.google.inject.{AbstractModule, Guice}
 import javax.annotation.PostConstruct
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[BeadledomLifecycleModule]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleModuleSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/BeadledomLifecycleModuleSpec.scala
@@ -2,15 +2,16 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import com.google.inject.{AbstractModule, Guice}
 import javax.annotation.PostConstruct
-import org.scalatest.{FunSpec, MustMatchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[BeadledomLifecycleModule]].
   *
   * @author John Leacox
   */
-class BeadledomLifecycleModuleSpec extends FunSpec with MustMatchers with MockitoSugar {
+class BeadledomLifecycleModuleSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("BeadledomLifecycleModule") {
     it("provides a binding for LifecycleProvisionListener") {
       val shutdownManager = mock[LifecycleShutdownManager]

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/InvokableLifecycleMethodImplSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/InvokableLifecycleMethodImplSpec.scala
@@ -2,17 +2,18 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import java.lang.reflect.Method
 import javax.annotation.PreDestroy
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[InvokableLifecycleMethodImpl]].
   *
   * @author John Leacox
   */
-class InvokableLifecycleMethodImplSpec extends FunSpec with MustMatchers with MockitoSugar {
+class InvokableLifecycleMethodImplSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("InvokableLifecycleMethodImpl") {
     describe("#invoke") {
       it("invokes the wrapped lifecycle method") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/InvokableLifecycleMethodImplSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/InvokableLifecycleMethodImplSpec.scala
@@ -2,10 +2,10 @@ package com.cerner.beadledom.lifecycle.legacy
 
 import java.lang.reflect.Method
 import javax.annotation.PreDestroy
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[InvokableLifecycleMethodImpl]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleProvisionListenerSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleProvisionListenerSpec.scala
@@ -6,16 +6,17 @@ import javax.annotation.{PostConstruct, PreDestroy}
 import org.hamcrest.Matchers.contains
 import org.mockito.Mockito
 import org.mockito.hamcrest.MockitoHamcrest
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.reflect.Manifest
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Unit tests for [[LifecycleProvisionListener]].
  *
  * @author John Leacox
  */
-class LifecycleProvisionListenerSpec extends FunSpec with MustMatchers with MockitoSugar {
+class LifecycleProvisionListenerSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("LifecycleProvisionListener") {
     describe("#onProvision") {
       it("executes PostConstruct methods on the injectee") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleProvisionListenerSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleProvisionListenerSpec.scala
@@ -6,9 +6,9 @@ import javax.annotation.{PostConstruct, PreDestroy}
 import org.hamcrest.Matchers.contains
 import org.mockito.Mockito
 import org.mockito.hamcrest.MockitoHamcrest
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.reflect.Manifest
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Unit tests for [[LifecycleProvisionListener]].

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleShutdownManagerImplSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleShutdownManagerImplSpec.scala
@@ -1,16 +1,17 @@
 package com.cerner.beadledom.lifecycle.legacy
 
 import org.mockito.Mockito
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[LifecycleShutdownManagerImpl]].
   *
   * @author John Leacox
   */
-class LifecycleShutdownManagerImplSpec extends FunSpec with MustMatchers with MockitoSugar {
+class LifecycleShutdownManagerImplSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("LifecycleShutdownManagerImpl") {
     describe("#addPreDestroyMethods") {
       it("adds to the full set of predestroy methods when called multiple times") {

--- a/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleShutdownManagerImplSpec.scala
+++ b/lifecycle/src/test/scala/com/cerner/beadledom/lifecycle/legacy/LifecycleShutdownManagerImplSpec.scala
@@ -1,9 +1,9 @@
 package com.cerner.beadledom.lifecycle.legacy
 
 import org.mockito.Mockito
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[LifecycleShutdownManagerImpl]].

--- a/newrelic-jaxrs/src/test/scala/com/cerner/beadledom/newrelic/jaxrs/NewRelicCorrelationIdFilterSpec.scala
+++ b/newrelic-jaxrs/src/test/scala/com/cerner/beadledom/newrelic/jaxrs/NewRelicCorrelationIdFilterSpec.scala
@@ -4,10 +4,12 @@ import com.cerner.beadledom.newrelic.NewRelicApi
 import javax.ws.rs.container.ContainerRequestContext
 import org.mockito.Mockito.{reset, verify, verifyZeroInteractions, when}
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 class NewRelicCorrelationIdFilterSpec
-  extends FunSpec with BeforeAndAfter with MustMatchers with MockitoSugar {
+  extends AnyFunSpec with BeforeAndAfter with Matchers with MockitoSugar {
 
   val headerName = "Correlation-Id"
   val id = java.util.UUID.randomUUID.toString

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListLinksWriterInterceptorSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListLinksWriterInterceptorSpec.scala
@@ -7,9 +7,9 @@ import org.jboss.resteasy.core.interception.AbstractWriterInterceptorContext
 import org.jboss.resteasy.spi.ResteasyUriInfo
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for OffsetPaginatedListLinksWriterInterceptor.

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListLinksWriterInterceptorSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListLinksWriterInterceptorSpec.scala
@@ -7,16 +7,17 @@ import org.jboss.resteasy.core.interception.AbstractWriterInterceptorContext
 import org.jboss.resteasy.spi.ResteasyUriInfo
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for OffsetPaginatedListLinksWriterInterceptor.
  *
  * @author John Leacox
  */
-class OffsetPaginatedListLinksWriterInterceptorSpec extends FunSpec with MustMatchers with MockitoSugar {
+class OffsetPaginatedListLinksWriterInterceptorSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("OffsetPaginatedListLinksWriterInterceptor") {
     describe("#aroundWriteTo") {
       it("replaces an OffsetPaginatedList entity with an OffsetPaginatedListDto entity") {

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListSpec.scala
@@ -1,14 +1,15 @@
 package com.cerner.beadledom.pagination
 
-import org.scalatest.{FunSpec, MustMatchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for OffsetPaginationList.
  *
  * @author John Leacox
  */
-class OffsetPaginatedListSpec extends FunSpec with MustMatchers with MockitoSugar {
+class OffsetPaginatedListSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("OffsetPaginatedList") {
     describe("Builder") {
       describe("#build") {

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginatedListSpec.scala
@@ -1,7 +1,7 @@
 package com.cerner.beadledom.pagination
 
 import org.scalatest.{FunSpec, MustMatchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for OffsetPaginationList.

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginationLinksSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginationLinksSpec.scala
@@ -4,9 +4,9 @@ import com.google.inject.Guice
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.UriInfo
 import org.jboss.resteasy.spi.ResteasyUriInfo
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for OffsetPaginationLinks.

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginationLinksSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/OffsetPaginationLinksSpec.scala
@@ -4,9 +4,10 @@ import com.google.inject.Guice
 import javax.ws.rs.WebApplicationException
 import javax.ws.rs.core.UriInfo
 import org.jboss.resteasy.spi.ResteasyUriInfo
-import org.scalatest.{FunSpec, MustMatchers}
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for OffsetPaginationLinks.
@@ -14,7 +15,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  * @author Ian Kottman
  */
-class OffsetPaginationLinksSpec extends FunSpec with MustMatchers with MockitoSugar {
+class OffsetPaginationLinksSpec extends AnyFunSpec with Matchers with MockitoSugar {
 
   // Allow static injection for pagination parameters
   Guice.createInjector(new OffsetPaginationModule())

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/parameters/LimitParameterSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/parameters/LimitParameterSpec.scala
@@ -5,14 +5,15 @@ import com.cerner.beadledom.pagination.models.OffsetPaginationConfiguration
 import com.google.inject.multibindings.OptionalBinder
 import com.google.inject.{AbstractModule, Guice}
 import javax.ws.rs.WebApplicationException
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec for LimitParameter.
  *
  * @author John Leacox
  */
-class LimitParameterSpec extends FunSpec with MustMatchers {
+class LimitParameterSpec extends AnyFunSpec with Matchers {
   describe("LimitParameter") {
     describe("#getValue") {
       it("throws an WebApplicationException if param is 0") {

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/parameters/OffsetPaginationParametersSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/parameters/OffsetPaginationParametersSpec.scala
@@ -7,15 +7,16 @@ import com.cerner.beadledom.pagination.models.OffsetPaginationConfiguration
 import com.google.inject.multibindings.OptionalBinder
 import com.google.inject.{AbstractModule, Guice, Injector}
 import org.jboss.resteasy.spi.ResteasyUriInfo
-import org.scalatest.{FunSpec, MustMatchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Spec for OffsetPaginatedListLinksWriterInterceptor.
   *
   * @author Ian Kottman
   */
-class OffsetPaginationParametersSpec extends FunSpec with MustMatchers with MockitoSugar {
+class OffsetPaginationParametersSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("OffsetPaginationParameters") {
     describe("#getLimit") {
       it("returns the default limit if no query parameter is present") {

--- a/pagination/src/test/scala/com/cerner/beadledom/pagination/parameters/OffsetPaginationParametersSpec.scala
+++ b/pagination/src/test/scala/com/cerner/beadledom/pagination/parameters/OffsetPaginationParametersSpec.scala
@@ -7,8 +7,8 @@ import com.cerner.beadledom.pagination.models.OffsetPaginationConfiguration
 import com.google.inject.multibindings.OptionalBinder
 import com.google.inject.{AbstractModule, Guice, Injector}
 import org.jboss.resteasy.spi.ResteasyUriInfo
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Spec for OffsetPaginatedListLinksWriterInterceptor.

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
     <beadledom.url>http://cerner.github.io/beadledom/${project.version}</beadledom.url>
     <autovalue.version>1.6.5</autovalue.version>
     <java.version>1.8</java.version>
-    <scala.version>2.13.1</scala.version>
-    <scala.binary.version>2.13</scala.binary.version>
+    <scala.version>2.12.11</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.10.0</jackson.version>
     <resteasy.version>3.6.3.Final</resteasy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
     <beadledom.url>http://cerner.github.io/beadledom/${project.version}</beadledom.url>
     <autovalue.version>1.6.5</autovalue.version>
     <java.version>1.8</java.version>
-    <scala.version>2.11.12</scala.version>
-    <scala.binary.version>2.11</scala.binary.version>
+    <scala.version>2.13.1</scala.version>
+    <scala.binary.version>2.13</scala.binary.version>
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.10.0</jackson.version>
     <resteasy.version>3.6.3.Final</resteasy.version>
@@ -103,7 +103,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
-    <scala-maven-plugin.version>3.4.1</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
     <spotbugs.plugin.version>3.1.5</spotbugs.plugin.version>
     <pmd.version>6.8.0</pmd.version>
     <pmd.plugin.version>3.10.0</pmd.plugin.version>
@@ -364,7 +364,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-configuration2</artifactId>
-        <version>2.2</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -419,7 +419,7 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.22.0-GA</version>
+        <version>3.27.0-GA</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
@@ -492,13 +492,13 @@
       <dependency>
         <groupId>org.scalacheck</groupId>
         <artifactId>scalacheck_${scala.binary.version}</artifactId>
-        <version>1.14.0</version>
+        <version>1.14.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.0.5</version>
+        <version>3.0.8</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -547,6 +547,13 @@
           <args>
             <arg>-nobootcp</arg>
           </args>
+          <compilerPlugins>
+            <compilerPlugin>
+              <groupId>org.scalameta</groupId>
+              <artifactId>semanticdb-scalac_${scala.version}</artifactId>
+              <version>4.3.7</version>
+            </compilerPlugin>
+          </compilerPlugins>
         </configuration>
         <executions>
           <execution>
@@ -691,6 +698,18 @@
         </dependencies>
       </plugin>
       <plugin>
+        <groupId>io.github.evis</groupId>
+        <artifactId>scalafix-maven-plugin</artifactId>
+        <version>0.1.2_0.9.5</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>autofix_${scala.binary.version}</artifactId>
+            <version>3.0.8-0</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <version>2.0.0</version>
@@ -706,7 +725,7 @@
           <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.0.5</version>
+            <version>3.0.8</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
     <beadledom.url>http://cerner.github.io/beadledom/${project.version}</beadledom.url>
     <autovalue.version>1.6.5</autovalue.version>
     <java.version>1.8</java.version>
-    <scala.version>2.12.11</scala.version>
-    <scala.binary.version>2.12</scala.binary.version>
+    <scala.version>2.13.1</scala.version>
+    <scala.binary.version>2.13</scala.binary.version>
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.10.0</jackson.version>
     <resteasy.version>3.6.3.Final</resteasy.version>
@@ -580,13 +580,6 @@
           <args>
             <arg>-nobootcp</arg>
           </args>
-          <compilerPlugins>
-            <compilerPlugin>
-              <groupId>org.scalameta</groupId>
-              <artifactId>semanticdb-scalac_${scala.version}</artifactId>
-              <version>4.3.7</version>
-            </compilerPlugin>
-          </compilerPlugins>
         </configuration>
         <executions>
           <execution>
@@ -727,18 +720,6 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>6.2</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>io.github.evis</groupId>
-        <artifactId>scalafix-maven-plugin</artifactId>
-        <version>0.1.2_0.9.5</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.scalatest</groupId>
-            <artifactId>autofix_${scala.binary.version}</artifactId>
-            <version>3.1.0.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,25 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.0.8</version>
+        <version>3.1.1</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatestplus</groupId>
+        <artifactId>junit-4-12_${scala.binary.version}</artifactId>
+        <version>3.1.1.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatestplus</groupId>
+        <artifactId>mockito-3-2_${scala.binary.version}</artifactId>
+        <version>3.1.1.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.scalatestplus</groupId>
+        <artifactId>scalacheck-1-14_${scala.binary.version}</artifactId>
+        <version>3.1.1.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -527,6 +545,21 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatestplus</groupId>
+      <artifactId>junit-4-12_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatestplus</groupId>
+      <artifactId>mockito-3-2_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatestplus</groupId>
+      <artifactId>scalacheck-1-14_${scala.binary.version}</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -705,7 +738,7 @@
           <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>autofix_${scala.binary.version}</artifactId>
-            <version>3.0.8-0</version>
+            <version>3.1.0.0</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -725,7 +758,7 @@
           <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
-            <version>3.0.8</version>
+            <version>3.1.1</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/resteasy-genericresponse/src/test/scala/com/cerner/beadledom/resteasy/BuiltGenericResponseSpec.scala
+++ b/resteasy-genericresponse/src/test/scala/com/cerner/beadledom/resteasy/BuiltGenericResponseSpec.scala
@@ -10,8 +10,8 @@ import javax.ws.rs.core._
 
 import org.mockito.Mockito._
 import org.scalacheck.Gen
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 /**
   * Specs tests for [[BuiltGenericResponse]]
@@ -19,7 +19,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
   * @author John Leacox
   */
 class BuiltGenericResponseSpec
-    extends UnitSpec with MockitoSugar with GeneratorDrivenPropertyChecks {
+    extends UnitSpec with MockitoSugar with ScalaCheckDrivenPropertyChecks {
   describe("BuiltGenericResponse") {
     describe("#create") {
       it("creates a new instance of BuiltGenericResponse") {

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
@@ -13,8 +13,8 @@ import org.apache.commons.configuration2.ImmutableHierarchicalConfiguration
 import org.jboss.resteasy.spi.{Registry, ResteasyDeployment, ResteasyProviderFactory}
 import org.mockito.Mockito._
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec to test the BaseContextListener.

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/BaseContextListenerSpec.scala
@@ -15,12 +15,14 @@ import org.mockito.Mockito._
 import org.scalatest._
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec to test the BaseContextListener.
  */
 class BaseContextListenerSpec
-    extends FunSpec with MockitoSugar with BeforeAndAfter with MustMatchers {
+    extends AnyFunSpec with MockitoSugar with BeforeAndAfter with Matchers {
 
   val context = mock[ServletContext]
   val deployment: ResteasyDeployment = mock[ResteasyDeployment]

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/InjectorProcessorSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/InjectorProcessorSpec.scala
@@ -2,8 +2,8 @@ package com.cerner.beadledom.resteasy
 
 import org.jboss.resteasy.spi.{Registry, ResteasyProviderFactory}
 import org.scalatest.{FunSpec, MustMatchers}
-import org.scalatest.mockito.MockitoSugar
 import com.google.inject.{AbstractModule, Guice}
+import org.scalatestplus.mockito.MockitoSugar
 
 class InjectorProcessorSpec extends FunSpec with MockitoSugar with MustMatchers{
 

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/InjectorProcessorSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/InjectorProcessorSpec.scala
@@ -1,11 +1,12 @@
 package com.cerner.beadledom.resteasy
 
 import org.jboss.resteasy.spi.{Registry, ResteasyProviderFactory}
-import org.scalatest.{FunSpec, MustMatchers}
 import com.google.inject.{AbstractModule, Guice}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
-class InjectorProcessorSpec extends FunSpec with MockitoSugar with MustMatchers{
+class InjectorProcessorSpec extends AnyFunSpec with MockitoSugar with Matchers{
 
   val registry: Registry = mock[Registry]
   val providerFactory: ResteasyProviderFactory = mock[ResteasyProviderFactory]

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyContextListenerSpecSuite.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyContextListenerSpecSuite.scala
@@ -8,11 +8,12 @@ import org.apache.commons.io.FileUtils
 import org.apache.naming.resources.VirtualDirContext
 import org.scalatest._
 import scala.collection.immutable.IndexedSeq
+import org.scalatest.funspec.AnyFunSpec
 
 /**
  * Suite of tests for Beadledom RestEasy based services.
  */
-class ResteasyContextListenerSpecSuite extends FunSpec with BeforeAndAfterAll {
+class ResteasyContextListenerSpecSuite extends AnyFunSpec with BeforeAndAfterAll {
 
   val tomcat = new Tomcat
   val tomcatPort = Integer.parseInt(System.getProperty("tomcat.http.port", "9091"))

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
@@ -9,9 +9,9 @@ import javax.ws.rs.client.Entity
 import javax.ws.rs.core.MediaType
 import org.apache.commons.io.FileUtils
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
 import play.api.libs.json.Json
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  *

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
@@ -9,9 +9,11 @@ import javax.ws.rs.client.Entity
 import javax.ws.rs.core.MediaType
 import org.apache.commons.io.FileUtils
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import play.api.libs.json.Json
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  *
@@ -21,8 +23,8 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
-    extends FunSpec with MockitoSugar with BeforeAndAfterAll with BeforeAndAfter with
-        MustMatchers {
+    extends AnyFunSpec with MockitoSugar with BeforeAndAfterAll with BeforeAndAfter with
+        Matchers {
 
   val client = new ResteasyClientBuilder().connectionPoolSize(5).register().build()
 

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/exceptionmapping/FailureExceptionMapperSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/exceptionmapping/FailureExceptionMapperSpec.scala
@@ -13,8 +13,8 @@ import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttp
 import org.jboss.resteasy.spi.{Failure, LoggableFailure, ReaderException, WriterException}
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
   * Unit tests for [[FailureExceptionMapper]].

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/exceptionmapping/FailureExceptionMapperSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/exceptionmapping/FailureExceptionMapperSpec.scala
@@ -13,8 +13,10 @@ import org.jboss.resteasy.mock.{MockDispatcherFactory, MockHttpRequest, MockHttp
 import org.jboss.resteasy.spi.{Failure, LoggableFailure, ReaderException, WriterException}
 import org.mockito.Mockito
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSpec, MustMatchers}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Unit tests for [[FailureExceptionMapper]].
@@ -22,7 +24,7 @@ import org.scalatestplus.mockito.MockitoSugar
   * @author Cal Fisher
   */
 class FailureExceptionMapperSpec
-    extends FunSpec with MustMatchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
+    extends AnyFunSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll with MockitoSugar {
 
   val failureExceptionMapper = new FailureExceptionMapper
   val helloDao = mock[HelloDao]

--- a/swagger2/src/test/scala/com/cerner/beadledom/swagger2/SwaggerGuiceJaxrsScannerSpec.scala
+++ b/swagger2/src/test/scala/com/cerner/beadledom/swagger2/SwaggerGuiceJaxrsScannerSpec.scala
@@ -6,8 +6,8 @@ import javax.servlet.ServletConfig
 import javax.ws.rs.core.Application
 import org.mockito.Mockito.{reset, when}
 import org.scalatest._
-import org.scalatest.mockito.MockitoSugar
 import scala.collection.JavaConverters._
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec tests for [SwaggerGuiceJaxrsScanner].

--- a/swagger2/src/test/scala/com/cerner/beadledom/swagger2/SwaggerGuiceJaxrsScannerSpec.scala
+++ b/swagger2/src/test/scala/com/cerner/beadledom/swagger2/SwaggerGuiceJaxrsScannerSpec.scala
@@ -8,6 +8,8 @@ import org.mockito.Mockito.{reset, when}
 import org.scalatest._
 import scala.collection.JavaConverters._
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
  * Spec tests for [SwaggerGuiceJaxrsScanner].
@@ -15,7 +17,7 @@ import org.scalatestplus.mockito.MockitoSugar
  * @author John Leacox
  */
 class SwaggerGuiceJaxrsScannerSpec
-    extends FunSpec with BeforeAndAfter with MustMatchers with MockitoSugar {
+    extends AnyFunSpec with BeforeAndAfter with Matchers with MockitoSugar {
   val swaggerInfo: Info = mock[Info]
 
   before {

--- a/testing/src/main/scala/com/cerner/beadledom/testing/UnitSpec.scala
+++ b/testing/src/main/scala/com/cerner/beadledom/testing/UnitSpec.scala
@@ -1,8 +1,9 @@
 package com.cerner.beadledom.testing
 
-import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
 
 /**
   * Abstract base class for Unit tests.
   */
-abstract class UnitSpec extends FunSpec with MustMatchers { }
+abstract class UnitSpec extends AnyFunSpec with Matchers { }


### PR DESCRIPTION
### What was changed? Why is this necessary?

Upgrades to Scala 2.12 and scalatest 3.1 so that we can be on the latest scalatest version. We still can't go to Scala 2.13 because some of our internally used Scala dependencies (for example gatling) only support 2.12 so far.


### How was it tested?

Existing tests

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
