### PR TITLE
Adding HttpHealthDependency helper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Beadledom Changelog
 
+## 3.7 - In Development
+### Added
+* `HttpHealthDependency` class for dependencies that are HTTP services. 
+
 ## 3.6 - 30th April 2020
 
 ### Added

--- a/docs/source/manual/health.rst
+++ b/docs/source/manual/health.rst
@@ -70,3 +70,21 @@ Usage
       return "foobar";
     }
   }
+
+* If your health dependency is a HTTP service, you can use the HttpHealthDependency_ class to declare your dependency.
+
+.. code-block:: java
+
+  public class MyModule extends AbstractModule {
+    @Override
+    public void configure() {
+      install(new HealthModule());
+    }
+
+    @ProvidesIntoSet
+    HealthDependency provideMyHealthDependency() {
+      return new HttpHealthDependency("https://base-url/meta/availability", "dependencyName", isPrimary);
+    }
+  }
+
+.. _HttpHealthDependency: https://github.com/cerner/beadledom/blob/master/health/service/src/main/java/com/cerner/beadledom/health/HealthDependency.java

--- a/health/service/pom.xml
+++ b/health/service/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>guice-multibindings</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
     </dependency>
@@ -54,10 +58,24 @@
     </dependency>
 
     <!-- Test Dependencies -->
-
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -65,5 +83,4 @@
       <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
-
 </project>

--- a/health/service/src/main/java/com/cerner/beadledom/health/HttpHealthDependency.java
+++ b/health/service/src/main/java/com/cerner/beadledom/health/HttpHealthDependency.java
@@ -1,0 +1,52 @@
+package com.cerner.beadledom.health;
+
+import java.io.IOException;
+import java.util.Objects;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Implementation of {@link HealthDependency} to check the health of any HTTP service.
+ */
+public class HttpHealthDependency extends HealthDependency {
+  private final String availabilityUrl;
+  private final String name;
+  private final OkHttpClient client;
+
+  /**
+   * Constructs an instance of {@link HttpHealthDependency} with the given parameters.
+   *
+   * @param availabilityUrl String representing URL of the availability health check.
+   * @param name String representing name of the dependency
+   * @param isPrimary Boolean representing whether the dependency is primary or not.
+   */
+  public HttpHealthDependency(String availabilityUrl, String name, boolean isPrimary) {
+    super(isPrimary);
+    Objects.requireNonNull(availabilityUrl);
+    Objects.requireNonNull(name);
+
+    this.availabilityUrl = availabilityUrl;
+    this.name = name;
+    this.client = new OkHttpClient.Builder().build();
+  }
+
+  @Override
+  public HealthStatus checkAvailability() {
+    Request request = new Request.Builder().url(availabilityUrl).head().build();
+
+    try (Response response = client.newCall(request).execute()) {
+      if (response.isSuccessful()) {
+        return HealthStatus.create(200, getName() + " is available.");
+      }
+      return HealthStatus.create(503, getName() + " is not available.");
+    } catch (IOException e) {
+      return HealthStatus.create(503, getName() + " is not available.");
+    }
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+}

--- a/health/service/src/main/java/com/cerner/beadledom/health/HttpHealthDependency.java
+++ b/health/service/src/main/java/com/cerner/beadledom/health/HttpHealthDependency.java
@@ -8,6 +8,8 @@ import okhttp3.Response;
 
 /**
  * Implementation of {@link HealthDependency} to check the health of any HTTP service.
+ *
+ * @author Venkatesh Sridharan.
  */
 public class HttpHealthDependency extends HealthDependency {
   private final String availabilityUrl;

--- a/health/service/src/main/java/com/cerner/beadledom/health/HttpHealthDependency.java
+++ b/health/service/src/main/java/com/cerner/beadledom/health/HttpHealthDependency.java
@@ -39,9 +39,9 @@ public class HttpHealthDependency extends HealthDependency {
 
     try (Response response = client.newCall(request).execute()) {
       if (response.isSuccessful()) {
-        return HealthStatus.create(200, getName() + " is available.");
+        return HealthStatus.create(response.code(), getName() + " is available.");
       }
-      return HealthStatus.create(503, getName() + " is not available.");
+      return HealthStatus.create(response.code(), getName() + " is not available.");
     } catch (IOException e) {
       return HealthStatus.create(503, getName() + " is not available.");
     }

--- a/health/service/src/test/java/com/cerner/beadledom/health/HttpHealthDependencyTest.java
+++ b/health/service/src/test/java/com/cerner/beadledom/health/HttpHealthDependencyTest.java
@@ -100,7 +100,7 @@ class HttpHealthDependencyTest {
   }
 
   @Nested
-  @DisplayName("#constructor")
+  @DisplayName("#getName")
   class GetName {
     @Test
     void returns_valid_name() {

--- a/health/service/src/test/java/com/cerner/beadledom/health/HttpHealthDependencyTest.java
+++ b/health/service/src/test/java/com/cerner/beadledom/health/HttpHealthDependencyTest.java
@@ -1,0 +1,111 @@
+package com.cerner.beadledom.health;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpHealthDependencyTest {
+
+  private static MockWebServer mockWebServer = new MockWebServer();
+
+  @BeforeAll
+  static void setup() throws IOException {
+    mockWebServer.start();
+  }
+
+  @AfterAll
+  static void shutDown() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Nested
+  @DisplayName("#checkAvailability")
+  class CheckAvailability {
+
+    @Nested
+    class when_service_is_healthy {
+      @Test
+      void returns_success() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+        HttpHealthDependency httpHealthDependency =
+            new HttpHealthDependency(
+                mockWebServer.url("/meta/availability").toString(), "testDependency", true);
+        HealthStatus healthStatus = httpHealthDependency.checkAvailability();
+
+        assertEquals(200, healthStatus.getStatus());
+        assertEquals("testDependency is available.", healthStatus.getMessage());
+      }
+    }
+
+    @Nested
+    class when_service_is_unhealthy {
+      @Test
+      void returns_failure() {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+        HttpHealthDependency httpHealthDependency =
+            new HttpHealthDependency(
+                mockWebServer.url("/meta/availability").toString(), "testDependency", true);
+        HealthStatus healthStatus = httpHealthDependency.checkAvailability();
+
+        assertEquals(503, healthStatus.getStatus());
+        assertEquals("testDependency is not available.", healthStatus.getMessage());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("#constructor")
+  class ConstructorTest {
+
+    @Nested
+    class when_url_is_null {
+      @Test
+      void throws_NullPointerException() {
+        assertThrows(
+            NullPointerException.class,
+            () -> new HttpHealthDependency(null, "testDependency", true));
+      }
+    }
+
+    @Nested
+    class when_name_is_null {
+      @Test
+      void throws_NullPointerException() {
+        assertThrows(
+            NullPointerException.class,
+            () -> new HttpHealthDependency("url", null, true));
+      }
+    }
+
+    @Nested
+    class when_parameters_are_valid {
+      @Test
+      void initializes_successfully() {
+        HttpHealthDependency healthDependency =
+            new HttpHealthDependency("url", "testDependency", true);
+        assertEquals("testDependency", healthDependency.getName());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("#constructor")
+  class GetName {
+    @Test
+    void returns_valid_name() {
+      assertEquals(
+          "testDependency", new HttpHealthDependency("url", "testDependency", true).getName());
+    }
+  }
+}

--- a/health/service/src/test/java/com/cerner/beadledom/health/HttpHealthDependencyTest.java
+++ b/health/service/src/test/java/com/cerner/beadledom/health/HttpHealthDependencyTest.java
@@ -58,7 +58,7 @@ class HttpHealthDependencyTest {
                 mockWebServer.url("/meta/availability").toString(), "testDependency", true);
         HealthStatus healthStatus = httpHealthDependency.checkAvailability();
 
-        assertEquals(503, healthStatus.getStatus());
+        assertEquals(500, healthStatus.getStatus());
         assertEquals("testDependency is not available.", healthStatus.getMessage());
       }
     }

--- a/health/service/src/test/scala/com/cerner/beadledom/health/HealthModuleSpec.scala
+++ b/health/service/src/test/scala/com/cerner/beadledom/health/HealthModuleSpec.scala
@@ -55,7 +55,39 @@ class HealthModuleSpec extends FunSpec with MustMatchers with MockitoSugar {
         dependencies.get("alpha") mustBe a[Dependency1]
         dependencies.get("beta") mustBe a[Dependency2]
       }
+
+      describe("when HTTP health dependency is used") {
+        val httpHealthDependencyModule: Module = new AbstractModule {
+          override def configure(): Unit = {
+
+            val healthDependencyBinder = Multibinder
+                .newSetBinder(binder(), classOf[HealthDependency])
+
+            install(mockModule)
+            install(new HealthModule)
+
+            healthDependencyBinder.addBinding().to(classOf[Dependency1])
+          }
+
+          @Inject
+          @Singleton
+          @ProvidesIntoSet
+          def provideHttpHealthDependency(): HealthDependency = {
+            new HttpHealthDependency("availabilityUrl", "gamma", true)
+          }
+        }
+
+        it("creates map of dependencies from set") {
+          val injector = Guice.createInjector(httpHealthDependencyModule)
+
+          val dependencies = injector.getInstance(Key.get(mapType))
+          dependencies must have size 2
+          dependencies.get("alpha") mustBe a[Dependency1]
+          dependencies.get("gamma") mustBe a[HttpHealthDependency]
+        }
+      }
     }
+
     it("it does not throw exceptions when there are no dependencies") {
       val injector = Guice.createInjector(new AbstractModule {
         override def configure(): Unit = {

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.10.2</jackson.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>
-    <okhttp3.version>4.2.2</okhttp3.version>
+    <okhttp3.version>4.6.0</okhttp3.version>
     <resteasy.version>3.11.2.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
@@ -110,7 +110,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
-    <scala-maven-plugin.version>3.4.1</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
     <spotbugs.plugin.version>3.1.5</spotbugs.plugin.version>
     <pmd.version>6.8.0</pmd.version>
     <pmd.plugin.version>3.10.0</pmd.plugin.version>
@@ -425,7 +425,7 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>1.3.50</version>
+        <version>1.3.72</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat</groupId>
@@ -561,7 +561,7 @@
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <version>3.0.5</version>
+        <version>3.0.8</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.10.2</jackson.version>
-    <junit.jupiter.version>5.5.2</junit.jupiter.version>
+    <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <okhttp3.version>4.6.0</okhttp3.version>
     <resteasy.version>3.11.2.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <governator.version>1.17.5</governator.version>
     <jackson.version>2.10.2</jackson.version>
     <junit.jupiter.version>5.5.2</junit.jupiter.version>
+    <okhttp3.version>4.2.2</okhttp3.version>
     <resteasy.version>3.11.2.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
@@ -309,6 +310,17 @@
         <version>4.3.0</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
+        <version>${okhttp3.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>okhttp</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.typesafe.play</groupId>
         <artifactId>play-json_${scala.binary.version}</artifactId>
         <version>2.7.4</version>
@@ -409,6 +421,11 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
         <version>4.4.10</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>1.3.50</version>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat</groupId>


### PR DESCRIPTION
### What was changed? Why is this necessary?

* Adding HttpHealthDependency class to enable checking health of HTTP services.


### How was it tested?

* Tests
* Consumed it in a service locally.


### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
