### PR TITLE
Add server relative quality factor to health resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Beadledom Changelog
 
 ## 3.7 - In Development
+
 ### Added
-* `HttpHealthDependency` class for dependencies that are HTTP services. 
+* `HttpHealthDependency` class for dependencies that are HTTP services.
+* Add server relative quality factor to health resources.
 
 ## 3.6 - 30th April 2020
 

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/AvailabilityResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/AvailabilityResource.java
@@ -19,7 +19,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Path("meta/availability")
 public interface AvailabilityResource {
   @GET
-  @Produces("text/html; qs=0.8")
+  @Produces(MediaType.TEXT_HTML)
   StreamingOutput getBasicAvailabilityCheckHtml();
 
   @ApiOperation(value = "Basic Availability Check",
@@ -35,7 +35,7 @@ public interface AvailabilityResource {
       @io.swagger.annotations.ApiResponse(code = 503, message = "unhealthy"),
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy")})
   @GET
-  @Produces("application/json; qs=0.9")
+  @Produces(MediaType.APPLICATION_JSON)
   @JsonView(HealthJsonViews.Availability.class)
   HealthDto getBasicAvailabilityCheck();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/AvailabilityResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/AvailabilityResource.java
@@ -10,7 +10,6 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 
 @Api(value = "/health",
@@ -20,7 +19,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Path("meta/availability")
 public interface AvailabilityResource {
   @GET
-  @Produces(MediaType.TEXT_HTML)
+  @Produces("text/html; qs=0.8")
   StreamingOutput getBasicAvailabilityCheckHtml();
 
   @ApiOperation(value = "Basic Availability Check",
@@ -36,7 +35,7 @@ public interface AvailabilityResource {
       @io.swagger.annotations.ApiResponse(code = 503, message = "unhealthy"),
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy")})
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces("application/json; qs=0.9")
   @JsonView(HealthJsonViews.Availability.class)
   HealthDto getBasicAvailabilityCheck();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/DependenciesResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/DependenciesResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
@@ -23,7 +22,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Path("meta/health/diagnostic/dependencies")
 public interface DependenciesResource {
   @GET
-  @Produces(MediaType.TEXT_HTML)
+  @Produces("text/html; qs=0.8")
   StreamingOutput getDependencyListingHtml();
 
   @ApiOperation(value = "Dependency Listing",
@@ -45,12 +44,12 @@ public interface DependenciesResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDependencyDto.class)})
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces("application/json; qs=0.9")
   @JsonView(HealthJsonViews.Dependency.class)
   List<HealthDependencyDto> getDependencyListing();
 
   @GET
-  @Produces(MediaType.TEXT_HTML)
+  @Produces("text/html; qs=0.8")
   @Path("/{name}")
   Response getDependencyAvailabilityCheckHtml(@PathParam("name") String name);
 
@@ -75,7 +74,7 @@ public interface DependenciesResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDependencyDto.class)})
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces("application/json; qs=0.9")
   @JsonView(HealthJsonViews.Dependency.class)
   @Path("/{name}")
   Response getDependencyAvailabilityCheck(@PathParam("name") String name);

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/DependenciesResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/DependenciesResource.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.StreamingOutput;
 @Path("meta/health/diagnostic/dependencies")
 public interface DependenciesResource {
   @GET
-  @Produces("text/html; qs=0.8")
+  @Produces(MediaType.TEXT_HTML)
   StreamingOutput getDependencyListingHtml();
 
   @ApiOperation(value = "Dependency Listing",
@@ -44,12 +44,12 @@ public interface DependenciesResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDependencyDto.class)})
   @GET
-  @Produces("application/json; qs=0.9")
+  @Produces(MediaType.APPLICATION_JSON)
   @JsonView(HealthJsonViews.Dependency.class)
   List<HealthDependencyDto> getDependencyListing();
 
   @GET
-  @Produces("text/html; qs=0.8")
+  @Produces(MediaType.TEXT_HTML)
   @Path("/{name}")
   Response getDependencyAvailabilityCheckHtml(@PathParam("name") String name);
 
@@ -74,7 +74,7 @@ public interface DependenciesResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDependencyDto.class)})
   @GET
-  @Produces("application/json; qs=0.9")
+  @Produces(MediaType.APPLICATION_JSON)
   @JsonView(HealthJsonViews.Dependency.class)
   @Path("/{name}")
   Response getDependencyAvailabilityCheck(@PathParam("name") String name);

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/DiagnosticResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/DiagnosticResource.java
@@ -20,7 +20,7 @@ import javax.ws.rs.core.Response;
 public interface DiagnosticResource {
 
   @GET
-  @Produces("text/html; qs=0.8")
+  @Produces(MediaType.TEXT_HTML)
   Response getDiagnosticHealthCheckHtml();
 
   @ApiOperation(value = "Diagnostic Health Check",
@@ -42,7 +42,7 @@ public interface DiagnosticResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDto.class)})
   @GET
-  @Produces("application/json; qs=0.9")
+  @Produces(MediaType.APPLICATION_JSON)
   @JsonView(HealthJsonViews.Diagnostic.class)
   Response getDiagnosticHealthCheck();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/DiagnosticResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/DiagnosticResource.java
@@ -10,7 +10,6 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/health",
@@ -21,7 +20,7 @@ import javax.ws.rs.core.Response;
 public interface DiagnosticResource {
 
   @GET
-  @Produces(MediaType.TEXT_HTML)
+  @Produces("text/html; qs=0.8")
   Response getDiagnosticHealthCheckHtml();
 
   @ApiOperation(value = "Diagnostic Health Check",
@@ -43,7 +42,7 @@ public interface DiagnosticResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDto.class)})
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces("application/json; qs=0.9")
   @JsonView(HealthJsonViews.Diagnostic.class)
   Response getDiagnosticHealthCheck();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/HealthResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/HealthResource.java
@@ -10,7 +10,6 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/health", description = "Health and dependency checks")
@@ -18,7 +17,7 @@ import javax.ws.rs.core.Response;
 @Path("meta/health")
 public interface HealthResource {
   @GET
-  @Produces(MediaType.TEXT_HTML)
+  @Produces("text/html; qs=0.8")
   Response getPrimaryHealthCheckHtml();
 
   @ApiOperation(value = "Primary Health Check",
@@ -40,7 +39,7 @@ public interface HealthResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDto.class)})
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces("application/json; qs=0.9")
   @JsonView(HealthJsonViews.Primary.class)
   Response getPrimaryHealthCheck();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/HealthResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/HealthResource.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.Response;
 @Path("meta/health")
 public interface HealthResource {
   @GET
-  @Produces("text/html; qs=0.8")
+  @Produces(MediaType.TEXT_HTML)
   Response getPrimaryHealthCheckHtml();
 
   @ApiOperation(value = "Primary Health Check",
@@ -39,7 +39,7 @@ public interface HealthResource {
       @io.swagger.annotations.ApiResponse(code = 200, message = "healthy",
           response = HealthDto.class)})
   @GET
-  @Produces("application/json; qs=0.9")
+  @Produces(MediaType.APPLICATION_JSON)
   @JsonView(HealthJsonViews.Primary.class)
   Response getPrimaryHealthCheck();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/MediaType.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/MediaType.java
@@ -1,0 +1,19 @@
+package com.cerner.beadledom.health.api;
+
+/**
+ * Media types for health resources.
+ */
+class MediaType {
+
+  /**
+   * A {@code String} constant representing {@value #TEXT_HTML} media type with a server relative
+   * quality factor of .8
+   */
+  final static String TEXT_HTML = "text/html; qs=0.8";
+
+  /**
+   * A {@code String} constant representing {@value #APPLICATION_JSON} media type with a server
+   * relative quality factor of .9
+   */
+  final static String APPLICATION_JSON = "application/json; qs=0.9";
+}

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/MediaType.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/MediaType.java
@@ -9,11 +9,11 @@ class MediaType {
    * A {@code String} constant representing {@value #TEXT_HTML} media type with a server relative
    * quality factor of .8
    */
-  final static String TEXT_HTML = "text/html; qs=0.8";
+  static final String TEXT_HTML = "text/html; qs=0.8";
 
   /**
    * A {@code String} constant representing {@value #APPLICATION_JSON} media type with a server
    * relative quality factor of .9
    */
-  final static String APPLICATION_JSON = "application/json; qs=0.9";
+  static final String APPLICATION_JSON = "application/json; qs=0.9";
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/VersionResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/VersionResource.java
@@ -8,7 +8,6 @@ import com.wordnik.swagger.annotations.ApiResponses;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.StreamingOutput;
 
 @Api(value = "/health",
@@ -19,7 +18,7 @@ import javax.ws.rs.core.StreamingOutput;
 public interface VersionResource {
 
   @GET
-  @Produces(MediaType.TEXT_HTML)
+  @Produces("text/html; qs=0.8")
   StreamingOutput getVersionInfoHtml();
 
   @ApiOperation(value = "Application Version Information",
@@ -35,6 +34,6 @@ public interface VersionResource {
       @io.swagger.annotations.ApiResponse(code = 503, message = "Service Unavailable"),
       @io.swagger.annotations.ApiResponse(code = 200, message = "Success")})
   @GET
-  @Produces(MediaType.APPLICATION_JSON)
+  @Produces("application/json; qs=0.9")
   BuildDto getVersionInfo();
 }

--- a/health/api/src/main/java/com/cerner/beadledom/health/api/VersionResource.java
+++ b/health/api/src/main/java/com/cerner/beadledom/health/api/VersionResource.java
@@ -18,7 +18,7 @@ import javax.ws.rs.core.StreamingOutput;
 public interface VersionResource {
 
   @GET
-  @Produces("text/html; qs=0.8")
+  @Produces(MediaType.TEXT_HTML)
   StreamingOutput getVersionInfoHtml();
 
   @ApiOperation(value = "Application Version Information",
@@ -34,6 +34,6 @@ public interface VersionResource {
       @io.swagger.annotations.ApiResponse(code = 503, message = "Service Unavailable"),
       @io.swagger.annotations.ApiResponse(code = 200, message = "Success")})
   @GET
-  @Produces("application/json; qs=0.9")
+  @Produces(MediaType.APPLICATION_JSON)
   BuildDto getVersionInfo();
 }

--- a/integration/service/pom.xml
+++ b/integration/service/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
     </dependency>
     <dependency>
       <groupId>com.cerner.beadledom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.2.3</version>
+      </dependency>
+      <dependency>
         <groupId>com.cerner.beadledom</groupId>
         <artifactId>beadledom-client</artifactId>
         <version>${project.version}</version>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -148,6 +148,11 @@
       <artifactId>tomcat-embed-jasper</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/resteasy/src/test/resources/com/cerner/beadledom/resteasy/expected/api-docs-health.json
+++ b/resteasy/src/test/resources/com/cerner/beadledom/resteasy/expected/api-docs-health.json
@@ -14,7 +14,7 @@
           "type": "HealthDto",
           "nickname": "getBasicAvailabilityCheck",
           "produces": [
-            "application/json"
+            "application/json; qs=0.9"
           ],
           "parameters": [],
           "responseMessages": [
@@ -40,7 +40,7 @@
           "type": "HealthDto",
           "nickname": "getPrimaryHealthCheck",
           "produces": [
-            "application/json"
+            "application/json; qs=0.9"
           ],
           "parameters": [],
           "responseMessages": [
@@ -71,7 +71,7 @@
           },
           "nickname": "getDependencyListing",
           "produces": [
-            "application/json"
+            "application/json; qs=0.9"
           ],
           "parameters": [],
           "responseMessages": [
@@ -99,7 +99,7 @@
           "type": "HealthDependencyDto",
           "nickname": "getDependencyAvailabilityCheck",
           "produces": [
-            "application/json"
+            "application/json; qs=0.9"
           ],
           "parameters": [
             {
@@ -135,7 +135,7 @@
           "type": "HealthDto",
           "nickname": "getDiagnosticHealthCheck",
           "produces": [
-            "application/json"
+            "application/json; qs=0.9"
           ],
           "parameters": [],
           "responseMessages": [
@@ -163,7 +163,7 @@
           "type": "BuildDto",
           "nickname": "getVersionInfo",
           "produces": [
-            "application/json"
+            "application/json; qs=0.9"
           ],
           "parameters": [],
           "responseMessages": [

--- a/resteasy/src/test/resources/log4j.properties
+++ b/resteasy/src/test/resources/log4j.properties
@@ -1,4 +1,0 @@
-log4j.rootLogger = DEBUG, stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.conversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n

--- a/resteasy/src/test/resources/logback.xml
+++ b/resteasy/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yy/MM/dd HH:mm:ss.SSS z} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
@@ -57,6 +57,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           val expected = Json.obj("message" -> "faux-service is available")
           response.readEntity(classOf[String]) must equalJson(expected)
         }
+
+        it("returns json if Accept header is not present") {
+          val response = client.target(s"$rootUrl/meta/availability").request().get()
+          response.getStatus must be(200)
+          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+        }
       }
 
       describe("/meta/health") {
@@ -97,6 +103,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
             "message" -> "faux-service is available"
           )
           response.readEntity(classOf[String]) must equalJson(expected)
+        }
+
+        it("returns json if Accept header is not present") {
+          val response = client.target(s"$rootUrl/meta/health").request().get()
+          response.getStatus must be(200)
+          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
         }
 
         it("returns text/html and 503 status") {
@@ -217,6 +229,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           response.readEntity(classOf[String]) must equalJson(expected)
         }
 
+        it("returns json if Accept header is not present") {
+          val response = client.target(s"$rootUrl/meta/health/diagnostic").request().get()
+          response.getStatus must be(200)
+          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+        }
+
         it("returns text/html and 503 status") {
           ImportantThingHealthDependency.healthy = false
           val response = client.target(s"$rootUrl/meta/health/diagnostic")
@@ -314,6 +332,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           )
           response.readEntity(classOf[String]) must equalJson(expected)
         }
+
+        it("returns json if Accept header is not present") {
+          val response = client.target(s"$rootUrl/meta/health/diagnostic/dependencies").request().get()
+          response.getStatus must be(200)
+          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+        }
       }
 
       describe("/meta/health/diagnostic/dependencies/{name}") {
@@ -342,6 +366,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           )
           response.readEntity(classOf[String]) must equalJson(expected)
         }
+
+//        it("returns json if Accept header is not present") {
+//          val response = client.target(s"$rootUrl/meta/health/diagnostic/dependencies/important-thing").request().get()
+//          response.getStatus must be(200)
+//          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+//        }
 
         it("returns text/html and non-200 status") {
           ImportantThingHealthDependency.healthy = false
@@ -416,6 +446,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
             "buildDateTime" -> "2016-07-29T06:12:33-05:00"
           )
           response.readEntity(classOf[String]) must equalJson(expected)
+        }
+
+        it("returns json if Accept header is not present") {
+          val response = client.target(s"$rootUrl/meta/version").request().get()
+          response.getStatus must be(200)
+          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
         }
       }
     }

--- a/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
+++ b/resteasy/src/test/scala/com/cerner/beadledom/resteasy/ResteasyServiceSpec.scala
@@ -62,6 +62,7 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           val response = client.target(s"$rootUrl/meta/availability").request().get()
           response.getStatus must be(200)
           response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+          response.close()
         }
       }
 
@@ -109,6 +110,7 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           val response = client.target(s"$rootUrl/meta/health").request().get()
           response.getStatus must be(200)
           response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+          response.close()
         }
 
         it("returns text/html and 503 status") {
@@ -233,6 +235,7 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           val response = client.target(s"$rootUrl/meta/health/diagnostic").request().get()
           response.getStatus must be(200)
           response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+          response.close()
         }
 
         it("returns text/html and 503 status") {
@@ -337,6 +340,7 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           val response = client.target(s"$rootUrl/meta/health/diagnostic/dependencies").request().get()
           response.getStatus must be(200)
           response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+          response.close()
         }
       }
 
@@ -367,11 +371,12 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           response.readEntity(classOf[String]) must equalJson(expected)
         }
 
-//        it("returns json if Accept header is not present") {
-//          val response = client.target(s"$rootUrl/meta/health/diagnostic/dependencies/important-thing").request().get()
-//          response.getStatus must be(200)
-//          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
-//        }
+        it("returns json if Accept header is not present") {
+          val response = client.target(s"$rootUrl/meta/health/diagnostic/dependencies/important-thing").request().get()
+          response.getStatus must be(200)
+          response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+          response.close()
+        }
 
         it("returns text/html and non-200 status") {
           ImportantThingHealthDependency.healthy = false
@@ -452,6 +457,7 @@ class ResteasyServiceSpec(rootUrl: String, tomcatPort: Int)
           val response = client.target(s"$rootUrl/meta/version").request().get()
           response.getStatus must be(200)
           response.getMediaType.toString must be(MediaType.APPLICATION_JSON)
+          response.close()
         }
       }
     }


### PR DESCRIPTION
### What was changed? Why is this necessary?

Adds [server relative quality factor](https://download.oracle.com/otn-pub/jcp/jaxrs-2_0_rev_A-mrel-eval-spec/jsr339-jaxrs-2.0-final-spec.pdf#section.3.5) to the health resources. Having this set removes the following message from being logged when calling a health endpoint without setting the `Accept` header.

```
WARN  o.jboss.resteasy.resteasy_jaxrs.i18n - RESTEASY002142: Multiple resource methods match request "GET /meta/health/". Selecting one. Matching methods: [public abstract javax.ws.rs.core.Response com.cerner.beadledom.health.api.HealthResource.getPrimaryHealthCheckHtml(), public abstract javax.ws.rs.core.Response com.cerner.beadledom.health.api.HealthResource.getPrimaryHealthCheck()]
```

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
