### PR TITLE
Upgrade Avro to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 4.1 - TBD
+
+### Changed
+* Upgrade Avro to 1.10.0.
+
 ## 4.0 - 26th June 2020
 
 [Migration guide](http://engineering.cerner.com/beadledom/4.0/docs/releases/Beadledom40.html) to Beadledom 4.0 from Beadledom 3.x.

--- a/avro/jackson/src/main/java/com/cerner/beadledom/avro/AvroMappingMixin.java
+++ b/avro/jackson/src/main/java/com/cerner/beadledom/avro/AvroMappingMixin.java
@@ -2,11 +2,16 @@ package com.cerner.beadledom.avro;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
 
 /**
- * A Jackson mapping mixin to ignore the Avro {@code getSchema()} method.
+ * A Jackson mapping mixin to ignore the Avro {@code getSchema()} and {@code getSpecificData()}
+ * methods.
  */
 abstract class AvroMappingMixin {
   @JsonIgnore
   abstract Schema getSchema();
+
+  @JsonIgnore
+  abstract SpecificData getSpecificData();
 }

--- a/avro/pom.xml
+++ b/avro/pom.xml
@@ -23,7 +23,7 @@
         <plugin>
           <groupId>org.apache.avro</groupId>
           <artifactId>avro-maven-plugin</artifactId>
-          <version>1.7.5</version>
+          <version>1.10.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/docs/source/releases/Beadledom40.rst
+++ b/docs/source/releases/Beadledom40.rst
@@ -3,12 +3,12 @@
 Beadledom 4.0
 =============
 
-To be released...
+Released June 26th, 2020
 
 New Features
 ------------
 
-- Updated resteasy to 4.x.
+- Updated RESTEasy to 4.x.
 
 Migrating from Beadledom 3.0
 ----------------------------

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -8,4 +8,5 @@ Releases
    :maxdepth: 1
 
       Beadledom 3.0 <Beadledom30>
+      Beadledom 4.0 <Beadledom40>
 

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
-        <version>1.7.7</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -161,7 +161,7 @@
         <!-- Generate Avro class sources for the tests -->
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>1.7.5</version>
+        <version>1.10.0</version>
         <configuration>
           <stringType>String</stringType>
         </configuration>


### PR DESCRIPTION
### What was changed? Why is this necessary?
Upgrades Avro to 1.10.0. There are CVE with Avro 1.7.5.


### How to test

> This is bare minimum acceptable testing

- [x] `./mvnw clean install -U`
