### PR TITLE
Update Beadledom Client to retry on SSLException when the cause is IOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 4.1.1 - 11th November 2020
+
+### Fixed
+* Starting with Java 1.8.0_272, [SSLSocketImpl wraps SocketException](https://bugs.openjdk.java.net/browse/JDK-8214339). Beadledom Client is updated to retry on SSLExceptions that occur because of IOExceptions.
+
 ## 4.1 - 28th July 2020
 
 ### Changed

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandler.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandler.java
@@ -2,6 +2,7 @@ package com.cerner.beadledom.client.resteasy;
 
 import java.io.IOException;
 import java.util.Random;
+import javax.net.ssl.SSLException;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.protocol.HttpContext;
 
@@ -24,7 +25,13 @@ class ExponentialBackoffHttpRequestRetryHandler extends StandardHttpRequestRetry
 
   @Override
   public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
-    if (!super.retryRequest(exception, executionCount, context)) {
+    IOException cause = exception;
+    if (exception instanceof SSLException
+        && exception.getCause() != null
+        && exception.getCause() instanceof IOException) {
+      cause = (IOException)exception.getCause();
+    }
+    if (!super.retryRequest(cause, executionCount, context)) {
       return false;
     }
 

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandlerSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandlerSpec.scala
@@ -1,5 +1,13 @@
 package com.cerner.beadledom.client.resteasy
 
+import java.net.SocketException
+
+import javax.net.ssl.SSLException
+import org.apache.http.{HttpRequest, HttpVersion}
+import org.apache.http.client.protocol.HttpClientContext
+import org.apache.http.message.BasicRequestLine
+import org.mockito.Mockito
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{FunSpec, MustMatchers}
 
 /**
@@ -7,8 +15,36 @@ import org.scalatest.{FunSpec, MustMatchers}
  *
  * @author John Leacox
  */
-class ExponentialBackoffHttpRequestRetryHandlerSpec extends FunSpec with MustMatchers {
+class ExponentialBackoffHttpRequestRetryHandlerSpec extends FunSpec with MustMatchers with MockitoSugar {
   describe("ExponentialBackoffHttpRequestRetryHandler") {
+
+    describe("#retryRequest") {
+      val httpContext = mock[HttpClientContext]
+      val request = mock[HttpRequest]
+      val requestLine = new BasicRequestLine("GET", "http://www.google.com/", HttpVersion.HTTP_1_1)
+      Mockito.when(request.getRequestLine).thenReturn(requestLine)
+      Mockito.when(httpContext.getRequest).thenReturn(request)
+      val retryHandler = new ExponentialBackoffHttpRequestRetryHandler(3, false)
+
+      it ("retries on SSLException that are caused by SocketException") {
+        val exception = new SSLException("SSLException", new SocketException())
+        val retry = retryHandler.retryRequest(exception, 1, httpContext)
+        retry mustBe true
+      }
+
+      it ("does not retry on SSLException that are caused by non-IOExceptions") {
+        val exception = new SSLException("SSLException", new RuntimeException())
+        val retry = retryHandler.retryRequest(exception, 1, httpContext)
+        retry mustBe false
+      }
+
+      it ("does not retry on SSLException that have no exception cause") {
+        val exception = new SSLException("SSLException")
+        val retry = retryHandler.retryRequest(exception, 1, httpContext)
+        retry mustBe false
+      }
+    }
+
     describe("#calculateRetryDelay") {
       it("returns 100 when executionCount is 1") {
         val retryHandler = new ExponentialBackoffHttpRequestRetryHandler(3, false)


### PR DESCRIPTION
Starting with Java 1.8.0_272, SSLSocketImpl wraps SocketException - https://bugs.openjdk.java.net/browse/JDK-8214339. Beadledom Client is updated to retry on SSLExceptions that occur because of IOExceptions.
