### PR TITLE
Update Beadledom Client to retry on SSLException when the cause is IOException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beadledom Changelog
 
+## 4.7.1 - 11th November 2020
+
+### Fixed
+* Starting with Java 1.8.0_272, [SSLSocketImpl wraps SocketException](https://bugs.openjdk.java.net/browse/JDK-8214339). Beadledom Client is updated to retry on SSLExceptions that occur because of IOExceptions.
+
 ## 3.7 - 27th May 2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Beadledom Changelog
 
-## 4.7.1 - 11th November 2020
+## 3.7.1 - 11th November 2020
 
 ### Fixed
 * Starting with Java 1.8.0_272, [SSLSocketImpl wraps SocketException](https://bugs.openjdk.java.net/browse/JDK-8214339). Beadledom Client is updated to retry on SSLExceptions that occur because of IOExceptions.

--- a/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandler.java
+++ b/client/resteasy-client/src/main/java/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandler.java
@@ -2,6 +2,7 @@ package com.cerner.beadledom.client.resteasy;
 
 import java.io.IOException;
 import java.util.Random;
+import javax.net.ssl.SSLException;
 import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.apache.http.protocol.HttpContext;
 
@@ -24,7 +25,14 @@ class ExponentialBackoffHttpRequestRetryHandler extends StandardHttpRequestRetry
 
   @Override
   public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
-    if (!super.retryRequest(exception, executionCount, context)) {
+    IOException cause = exception;
+    if (exception instanceof SSLException
+        && exception.getCause() != null
+        && exception.getCause() instanceof IOException) {
+      cause = (IOException) exception.getCause();
+    }
+
+    if (!super.retryRequest(cause, executionCount, context)) {
       return false;
     }
 

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandlerSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ExponentialBackoffHttpRequestRetryHandlerSpec.scala
@@ -1,14 +1,48 @@
 package com.cerner.beadledom.client.resteasy
 
+import java.net.SocketException
+import javax.net.ssl.SSLException
+import org.apache.http.{HttpRequest, HttpVersion}
+import org.apache.http.client.protocol.HttpClientContext
+import org.apache.http.message.BasicRequestLine
+import org.mockito.Mockito
 import org.scalatest.{FunSpec, MustMatchers}
+import org.scalatestplus.mockito.MockitoSugar
 
 /**
  * Spec for ExponentialBackoffHttpRequestRetryHandler
  *
  * @author John Leacox
  */
-class ExponentialBackoffHttpRequestRetryHandlerSpec extends FunSpec with MustMatchers {
+class ExponentialBackoffHttpRequestRetryHandlerSpec extends FunSpec with MustMatchers with MockitoSugar {
   describe("ExponentialBackoffHttpRequestRetryHandler") {
+    describe("#retryRequest") {
+      val httpContext = mock[HttpClientContext]
+      val request = mock[HttpRequest]
+      val requestLine = new BasicRequestLine("GET", "http://www.google.com/", HttpVersion.HTTP_1_1)
+      Mockito.when(request.getRequestLine).thenReturn(requestLine)
+      Mockito.when(httpContext.getRequest).thenReturn(request)
+      val retryHandler = new ExponentialBackoffHttpRequestRetryHandler(3, false)
+
+      it ("retries on SSLException that are caused by SocketException") {
+        val exception = new SSLException("SSLException", new SocketException())
+        val retry = retryHandler.retryRequest(exception, 1, httpContext)
+        retry mustBe true
+      }
+
+      it ("does not retry on SSLException that are caused by non-IOExceptions") {
+        val exception = new SSLException("SSLException", new RuntimeException())
+        val retry = retryHandler.retryRequest(exception, 1, httpContext)
+        retry mustBe false
+      }
+
+      it ("does not retry on SSLException that have no exception cause") {
+        val exception = new SSLException("SSLException")
+        val retry = retryHandler.retryRequest(exception, 1, httpContext)
+        retry mustBe false
+      }
+    }
+
     describe("#calculateRetryDelay") {
       it("returns 100 when executionCount is 1") {
         val retryHandler = new ExponentialBackoffHttpRequestRetryHandler(3, false)

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,7 +10,14 @@
     <cve>CVE-2012-6708</cve>
     <cve>CVE-2015-9251</cve>
     <cve>CVE-2019-11358</cve>
+    <cve>CVE-2020-11022</cve> <!-- We don't pass HTML to DOM manipulation methods -->
+    <cve>CVE-2020-11023</cve> <!-- We don't pass HTML to DOM manipulation methods -->
     <vulnerabilityName>Regex in its jQuery.htmlPrefilter  sometimes may introduce XSS</vulnerabilityName>
+  </suppress>
+
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org.jboss.resteasy/resteasy-.*$</packageUrl>
+    <cve>CVE-2020-25633</cve>
   </suppress>
 
   <suppress>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,6 +18,17 @@
   <suppress>
     <packageUrl regex="true">^pkg:maven/org.jboss.resteasy/resteasy-.*$</packageUrl>
     <cve>CVE-2020-25633</cve>
+    <cve>CVE-2020-1695</cve>
+  </suppress>
+
+  <suppress>
+    <packageUrl regex="true">^pkg:maven/org.yaml/snakeyaml@1.24.*$</packageUrl>
+    <cve>CVE-2017-18640</cve>
+  </suppress>
+
+  <suppress>
+    <packageUrl regex="true">pkg:maven/org.jboss.resteasy/resteasy-guice@3.11.2.Final.*$</packageUrl>
+    <cve>CVE-2020-1695</cve>
   </suppress>
 
   <suppress>

--- a/pom.xml
+++ b/pom.xml
@@ -722,7 +722,7 @@
       <plugin>
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
-        <version>5.2.2</version>
+        <version>6.0.3</version>
         <configuration>
           <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
           <suppressionFile>dependency-check-suppressions.xml</suppressionFile>

--- a/pom.xml
+++ b/pom.xml
@@ -95,14 +95,14 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.5</governator.version>
-    <jackson.version>2.10.2</jackson.version>
+    <jackson.version>2.11.1</jackson.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <okhttp3.version>4.6.0</okhttp3.version>
-    <resteasy.version>3.11.2.Final</resteasy.version>
+    <resteasy.version>3.13.2.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
     <swagger-core.version>1.3.12</swagger-core.version>
-    <swagger2-core.version>1.5.22</swagger2-core.version>
+    <swagger2-core.version>1.6.2</swagger2-core.version>
     <tomcat-embed.version>7.0.104</tomcat-embed.version>
     <wagon.version>2.10</wagon.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,10 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <governator.version>1.17.5</governator.version>
-    <jackson.version>2.11.1</jackson.version>
+    <jackson.version>2.10.2</jackson.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <okhttp3.version>4.6.0</okhttp3.version>
-    <resteasy.version>3.13.2.Final</resteasy.version>
+    <resteasy.version>3.11.2.Final</resteasy.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <stagemonitor.version>0.22.0</stagemonitor.version>
     <swagger-core.version>1.3.12</swagger-core.version>


### PR DESCRIPTION
### What was changed? Why is this necessary?
With Java 1.8.0_272 SSLSocketImpl wraps SocketException - https://bugs.openjdk.java.net/browse/JDK-8214339. Beadledom Client is updated to retry on SSLExceptions that occur because of IOExceptions.

See also: https://github.com/cerner/beadledom/pull/193


### How was it tested?
mvn clean install


### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
