### PR TITLE
Upgrade swagger2 and jackson versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,13 +97,13 @@
     <scala.version>2.12.11</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <governator.version>1.17.10</governator.version>
-    <jackson.version>2.10.4</jackson.version>
+    <jackson.version>2.12.0</jackson.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <resteasy.version>4.5.6.Final</resteasy.version>
     <okhttp3.version>4.7.2</okhttp3.version>
     <spotbugs.version>3.1.8</spotbugs.version>
     <spotbugs.plugin.version>3.1.8</spotbugs.plugin.version>
-    <swagger2-core.version>1.6.1</swagger2-core.version>
+    <swagger2-core.version>1.6.2</swagger2-core.version>
     <tomcat-embed.version>7.0.104</tomcat-embed.version>
     <wagon.version>2.10</wagon.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
@@ -406,7 +406,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.12</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### What was changed? Why is this necessary?
When upgrading jackson to mitigate CVE-2020-25649 in a consuming project, we needed to bump the swagger2 version because they are using a deprecated method.

Swagger core issue: https://github.com/swagger-api/swagger-core/issues/3554
Swagger core commit:  https://github.com/swagger-api/swagger-core/commit/0724ec80d214e97ddb8b8416f2b2cbad4651281c

### How was it tested?
Built locally.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
