### PR TITLE
Updated deprecated constants

### DIFF
--- a/client/beadledom-client-example/example-service/src/main/java/com/cerner/beadledom/client/example/FauxModule.java
+++ b/client/beadledom-client-example/example-service/src/main/java/com/cerner/beadledom/client/example/FauxModule.java
@@ -46,8 +46,7 @@ public class FauxModule extends AbstractModule {
   ObjectMapper provideObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
 
-    objectMapper.setPropertyNamingStrategy(
-        PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedObjectMapperProvider.java
+++ b/client/beadledom-client-jackson/src/main/java/com/cerner/beadledom/client/jackson/AnnotatedObjectMapperProvider.java
@@ -66,8 +66,7 @@ class AnnotatedObjectMapperProvider implements Provider<ObjectMapper> {
 
     // Sets default values before looking at bound features
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
-    objectMapper.setPropertyNamingStrategy(
-        PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 

--- a/client/resteasy-client/src/test/java/com/cerner/beadledom/client/FauxModule.java
+++ b/client/resteasy-client/src/test/java/com/cerner/beadledom/client/FauxModule.java
@@ -32,8 +32,7 @@ public class FauxModule extends AbstractModule {
   ObjectMapper provideObjectMapper() {
     ObjectMapper objectMapper = new ObjectMapper();
 
-    objectMapper.setPropertyNamingStrategy(
-        PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ResteasyClientSpec.scala
+++ b/client/resteasy-client/src/test/scala/com/cerner/beadledom/client/resteasy/ResteasyClientSpec.scala
@@ -147,8 +147,7 @@ class ResteasyClientSpec(contextRoot: String, servicePort: Int)
     */
   private def getDefaultBeadledomObjectMapper: ObjectMapper = {
     val objectMapper: ObjectMapper = new ObjectMapper
-    objectMapper
-        .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES)
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT)
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)

--- a/jackson/src/main/java/com/cerner/beadledom/jackson/ObjectMapperProvider.java
+++ b/jackson/src/main/java/com/cerner/beadledom/jackson/ObjectMapperProvider.java
@@ -45,8 +45,7 @@ class ObjectMapperProvider implements Provider<ObjectMapper> {
 
     // Sets default values before looking at bound features
     objectMapper.setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
-    objectMapper.setPropertyNamingStrategy(
-        PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
@@ -75,4 +74,3 @@ class ObjectMapperProvider implements Provider<ObjectMapper> {
     return objectMapper;
   }
 }
-


### PR DESCRIPTION
### What was changed? Why is this necessary?

This is a minimalist attempt to enable users of Beadledom 3.X to address CVEs related to Jackson Databind. The deprecated constant has been removed in Jackson Databind 2.16. 

### How was it tested?

> Describe the strategy you used to validate these changes. For example, this should mention if you added unit/integration tests and summarize any manual testing you performed by running your branch locally or in a dev environment.

The project cannot be tested in its current state. However, [considering the nature of the modifications](https://github.com/FasterXML/jackson-databind/blob/569b76b641937890fa7e7aaf0bbe0a1fe43d26f2/src/main/java/com/fasterxml/jackson/databind/PropertyNamingStrategy.java#L438), I do not see it as necessary.

### How to test

> This is bare minimum acceptable testing

- [ ] `./mvnw clean install -U`
